### PR TITLE
Types: Fix TrailKeyItemProps not recognising booleans

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -178,7 +178,7 @@ export class Transition<
 > extends PureComponent<TransitionProps<S, DS> & S> {}
 
 type TrailKeyProps = string | number
-type TrailKeyItemProps = string | number | object
+type TrailKeyItemProps = boolean | string | number | object
 
 interface TrailProps<S extends object, DS extends object = {}> {
   native?: boolean


### PR DESCRIPTION
Similar to https://github.com/drcmda/react-spring/pull/284, this PR adds `boolean` type support for `TrailKeyItemProps`