### PR TITLE
Fix wrong useTransition values parameter typing

### DIFF
--- a/types/web.d.ts
+++ b/types/web.d.ts
@@ -214,7 +214,7 @@ export interface UseTransitionResult<TItem, DS extends object> {
   props: AnimatedValue<ForwardedProps<DS>>
 }
 
-export function useTransition<TItem, DS extends CSSProperties>(
+export function useTransition<TItem, DS extends object>(
   items: ReadonlyArray<TItem> | TItem | null | undefined,
   keys:
     | ((item: TItem) => TransitionKeyProps)


### PR DESCRIPTION
Hi here 👋 

I think the typing was wrong here, we should be able to pass custom property names using `useTransition` and not only `CSSProperties`:

```javascript
const transitions = useTransition(myState, null, {
  from: { custom: -10 }, // TS error here
  enter: { custom: 0 }, // TS error here
  leave: { custom: -10 }, // TS error here
})
```