### PR TITLE
fix type: use imported RefObject

### DIFF
--- a/types/web.d.ts
+++ b/types/web.d.ts
@@ -104,7 +104,7 @@ export interface HooksBaseProps
   native?: never
   // there is an undocumented onKeyframesHalt which passes the controller instance,
   // so it also cannot be typed unless Controller types are written
-  ref?: React.RefObject<ReactSpringHook>
+  ref?: RefObject<ReactSpringHook>
 }
 
 export interface UseSpringBaseProps extends HooksBaseProps {


### PR DESCRIPTION
I was running into an typescript error when doing a production build in a preact project:
```
ERROR in [at-loader] ./node_modules/react-spring/web.d.ts:107:15
    **TS2694: Namespace 'React' has no exported member 'RefObject'.**
```
Fix: Use the imported RefObject (like in all other places in the file).

Amazing project and great demos btw!