### PR TITLE
chore: use opencollective-postinstall pkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:dev": "jest --watch --no-coverage",
     "test:coverage:watch": "jest --watch",
     "test:ts": "tsc --noEmit",
-    "postinstall": "node -e \"console.log('\\u001b[35m\\u001b[1mEnjoy react-spring? You can now donate to our open collective:\\u001b[22m\\u001b[39m\\n > \\u001b[34mhttps://opencollective.com/react-spring/donate\\u001b[0m')\""
+    "postinstall": "opencollective-postinstall"
   },
   "husky": {
     "hooks": {
@@ -105,6 +105,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.3.1",
+    "opencollective-postinstall": "^2.0.3",
     "prop-types": "^15.5.8"
   },
   "jest": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5904,6 +5904,11 @@ onetime@^2.0.0:
   dependencies:
     mimic-fn "^1.0.0"
 
+opencollective-postinstall@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
+  integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
+
 opn@^3.0.2:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/opn/-/opn-3.0.3.tgz#b6d99e7399f78d65c3baaffef1fb288e9b85243a"


### PR DESCRIPTION

A suggestion to use https://github.com/opencollective/opencollective-postinstall package
instead of self-written solution.

why?

To support useful env variables: 
```js
isTrue(process.env.DISABLE_OPENCOLLECTIVE) || 
isTrue(process.env.OPEN_SOURCE_CONTRIBUTOR) || 
isTrue(process.env.CI)
```

Checked postinstall script after packing with current changes:

```sh
npm i ../react-spring/react-spring-8.0.27.tgz

> react-spring@8.0.27 postinstall /Users/yeti-or/Projects/tmp/hello/node_modules/react-spring
> opencollective-postinstall

Thank you for using react-spring!
If you rely on this package, please consider supporting our open collective:
> https://opencollective.com/react-spring/donate

npm WARN react-spring@8.0.27 requires a peer of react@>= 16.8.0 but none is installed. You must install peer dependencies yourself.
npm WARN react-spring@8.0.27 requires a peer of react-dom@>= 16.8.0 but none is installed. You must install peer dependencies yourself.
npm WARN hello@1.0.0 No description
npm WARN hello@1.0.0 No repository field.

+ react-spring@8.0.27
added 9 packages from 8 contributors and audited 9 packages in 1.573s
found 0 vulnerabilities
```