### PR TITLE
Issue template: spectrum -> github discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -6,4 +6,4 @@ about: Ask the maintainers (as a last resort)
 
 ## 🤓 Question
 
-(You _must_ search the issues before asking your question. Please consider asking in [the official Spectrum community](https://spectrum.chat/react-spring) and/or [Stack Overflow](https://stackoverflow.com) first.)
+(You _must_ search the issues before asking your question. Please consider asking in [the Discussions tab](https://github.com/pmndrs/react-spring/discussions) and/or [Stack Overflow](https://stackoverflow.com) first.)


### PR DESCRIPTION
linking to **GitHub discussions** instead of **spectrum** as suggested in https://spectrum.chat/react-spring/general/moving-over-to-github-discussions~1e82c200-0f8f-48b5-9ef4-6ef123caf838