### PR TITLE
fix: scrollTop is not set when from & to are equal #1185

### DIFF
--- a/packages/animated/src/withAnimated.tsx
+++ b/packages/animated/src/withAnimated.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import { forwardRef, useRef, Ref, useCallback } from 'react'
+import { forwardRef, useRef, Ref, useCallback, useEffect } from 'react'
 import { useLayoutEffect } from 'react-layout-effect'
 import {
   is,
@@ -44,7 +44,8 @@ export const withAnimated = (Component: any, host: HostConfig) => {
     const [props, deps] = getAnimatedState(givenProps, host)
 
     const forceUpdate = useForceUpdate()
-    const observer = new PropsObserver(() => {
+
+    const callback = () => {
       const instance = instanceRef.current
       if (hasInstance && !instance) {
         // Either this component was unmounted before changes could be
@@ -60,7 +61,9 @@ export const withAnimated = (Component: any, host: HostConfig) => {
       if (didUpdate === false) {
         forceUpdate()
       }
-    }, deps)
+    }
+
+    const observer = new PropsObserver(callback, deps)
 
     const observerRef = useRef<PropsObserver>()
     useLayoutEffect(() => {
@@ -77,6 +80,7 @@ export const withAnimated = (Component: any, host: HostConfig) => {
       }
     })
 
+    useEffect(callback, [])
     // Stop observing on unmount.
     useOnce(() => () => {
       const observer = observerRef.current!


### PR DESCRIPTION
#1185

I think the issue was that we were not calling applyAnimatedValues on the first render (which is getting called on the first render in v8) and thus scroll top was not working. I was able to reproduce and fix it on my local. 