### PR TITLE
fix: fix message channel error

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@rollup/plugin-commonjs": "^11.1.0",
     "@rollup/plugin-node-resolve": "^7.1.3",
     "@types/jest": "^24.0.13",
+    "@types/node": "^14.14.35",
     "@types/react": "^16.8.19",
     "build-if-changed": "^1.5.0",
     "chalk": "^2.4.2",

--- a/packages/core/src/hooks/useTransition.test.tsx
+++ b/packages/core/src/hooks/useTransition.test.tsx
@@ -3,7 +3,13 @@ import { RenderResult, render } from '@testing-library/react'
 import { toArray } from '@react-spring/shared'
 import { TransitionFn, UseTransitionProps } from '../types'
 import { useTransition } from './useTransition'
+import { MessageChannel as MessageChannelPolyfill } from 'worker_threads'
 
+beforeAll(() => {
+  if (!window.MessageChannel) {
+    window.MessageChannel = (MessageChannelPolyfill as unknown) as typeof window.MessageChannel
+  }
+})
 describe('useTransition', () => {
   let transition: TransitionFn
   let rendered: any[]

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -4,7 +4,7 @@
     "baseUrl": ".",
     "forceConsistentCasingInFileNames": true,
     "jsx": "react",
-    "lib": ["es2017"],
+    "lib": ["es2017", "DOM"],
     "moduleResolution": "node",
     "noErrorTruncation": true,
     "noEmitOnError": true,
@@ -15,6 +15,7 @@
     "sourceMap": true,
     "strict": true,
     "target": "esnext",
+    "module": "ESNext",
     "typeRoots": ["../../node_modules/@types", "../../@types"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2559,6 +2559,11 @@
   resolved "https://registry.npmjs.org/@types/node/-/node-14.14.14.tgz#f7fd5f3cc8521301119f63910f0fb965c7d761ae"
   integrity sha512-UHnOPWVWV1z+VV8k6L1HhG7UbGBgIdghqF3l9Ny9ApPghbjICXkUJSd/b9gOgQfjM1r+37cipdw/HJ3F6ICEnQ==
 
+"@types/node@^14.14.35":
+  version "14.14.35"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.35.tgz#42c953a4e2b18ab931f72477e7012172f4ffa313"
+  integrity sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
+
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
   resolved "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"


### PR DESCRIPTION
As we talked in discord, for some machines, testing doesn't have MessageChannel API, so I pollyfilled it and removed the error message to work properly.