### PR TITLE
Fix: Ensure onStart & onRest are called when immediate is true

### DIFF
--- a/packages/core/src/Controller.test.ts
+++ b/packages/core/src/Controller.test.ts
@@ -632,5 +632,27 @@ describe('Controller', () => {
         item
       )
     })
+
+    test('onStart & onRest are flushed even if the `immediate` prop is true', async () => {
+      const onRest = jest.fn()
+      const onStart = jest.fn()
+
+      const ctrl = new Controller<{ t: number }>({
+        t: 0,
+        onStart,
+        onRest,
+      })
+
+      ctrl.start({
+        t: 1,
+        immediate: true,
+      })
+
+      await global.advanceUntilIdle()
+
+      expect(ctrl.get().t).toBe(1)
+      expect(onStart).toHaveBeenCalled()
+      expect(onRest).toHaveBeenCalled()
+    })
   })
 })

--- a/packages/core/src/Controller.ts
+++ b/packages/core/src/Controller.ts
@@ -244,7 +244,9 @@ export class Controller<State extends Lookup = Lookup> {
     const { onStart, onChange, onRest } = this._events
 
     const active = this._active.size > 0
-    if (active && !this._started) {
+    const changed = this._changed.size > 0
+
+    if ((active && !this._started) || (changed && !this._started)) {
       this._started = true
       flush(onStart, ([onStart, result]) => {
         result.value = this.get()
@@ -253,10 +255,9 @@ export class Controller<State extends Lookup = Lookup> {
     }
 
     const idle = !active && this._started
-    const changed = this._changed.size > 0 && onChange.size
     const values = changed || (idle && onRest.size) ? this.get() : null
 
-    if (changed) {
+    if (changed && onChange.size) {
       flush(onChange, ([onChange, result]) => {
         result.value = values
         onChange(result, this, this._item)

--- a/packages/core/src/SpringValue.test.ts
+++ b/packages/core/src/SpringValue.test.ts
@@ -624,6 +624,18 @@ function describeEvents() {
       spring.finish()
       expect(onStart).toBeCalledTimes(1)
     })
+    it('is called when immediate is set to true', async () => {
+      const onStart = jest.fn()
+      new SpringValue({
+        from: 0,
+        to: 1,
+        onStart,
+        immediate: true,
+      })
+
+      global.mockRaf.step()
+      expect(onStart).toBeCalledTimes(1)
+    })
   })
   describe('the "onChange" event', () => {
     it('is called on every frame', async () => {
@@ -792,6 +804,18 @@ function describeEvents() {
         value: spring.get(),
         finished: true,
       })
+    })
+    it('is called when immediate is set to true', async () => {
+      const onRest = jest.fn()
+      new SpringValue({
+        from: 0,
+        to: 1,
+        onRest,
+        immediate: true,
+      })
+
+      global.mockRaf.step()
+      expect(onRest).toBeCalledTimes(1)
     })
   })
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

resolves #1419

### What

<!-- what have you done, if its a bug, whats your solution? -->

check if _changed.size is larger than 0 to and the spring has not started to fire the `onStart` event handlers. In the case of setting `immediate` `_active` set is added then taken away to quickly for the event to fire. However the value has changed. We should do a double check to avoid this edge case.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
