### PR TITLE
fix(parallax): scrollTo gets correct scroll value

### DIFF
--- a/packages/parallax/src/index.tsx
+++ b/packages/parallax/src/index.tsx
@@ -208,10 +208,12 @@ export const Parallax = React.memo(
       const scrollType = getScrollType(horizontal)
 
       state.offset = offset
+
+      state.controller.set({ scroll: state.current })
       state.controller.stop().start({
         scroll: offset * state.space,
         config,
-        onChange({ scroll }: any) {
+        onChange({ value: { scroll } }: any) {
           container[scrollType] = scroll
         },
       })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why
Resolves #1454. Parallax will now animate `scrollTo` correctly.
<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What
Changed the destructuring of the `value` of  `controller` in `onChange`.

I also added a line at 212 to set the `controller`'s value to `state.current` before animating because otherwise it started with stale state (In the current version `state.current` will cause the `controller` to always start at the number from the previous call to `scrollTo`).

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated: n/a
- [ ] Demo added: n/a
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
