### PR TITLE
fix(parallax): child horizontal prop defaults to parent's

### DIFF
--- a/demo/src/sandboxes/parallax/src/styles.module.css
+++ b/demo/src/sandboxes/parallax/src/styles.module.css
@@ -20,7 +20,6 @@
 .number span {
   display: inline-block;
   position: relative;
-  transform: translate3d(-35%, 0, 0);
 }
 
 .slopeBegin {

--- a/packages/parallax/src/index.tsx
+++ b/packages/parallax/src/index.tsx
@@ -54,9 +54,6 @@ export const ParallaxLayer = React.memo(
       // Our parent controls our height and position.
       const parent = useContext<IParallax>(ParentContext)
 
-      // Layer's horizontal defaults to parent's horizontal if not set.
-      if (horizontal === undefined) horizontal = parent.horizontal
-
       // This is how we animate.
       const ctrl = useMemoOne(() => {
         const targetScroll = Math.floor(offset) * parent.space
@@ -105,8 +102,12 @@ export const ParallaxLayer = React.memo(
         }
       })
 
+      // Layer's horizontal defaults to parent's horizontal if not set.
+      const scrollHorizontal =
+        horizontal === undefined ? parent.horizontal : horizontal
+
       const translate3d = ctrl.springs.translate.to(
-        horizontal
+        scrollHorizontal
           ? x => `translate3d(${x}px,0,0)`
           : y => `translate3d(0,${y}px,0)`
       )
@@ -119,8 +120,8 @@ export const ParallaxLayer = React.memo(
             backgroundSize: 'auto',
             backgroundRepeat: 'no-repeat',
             willChange: 'transform',
-            [horizontal ? 'height' : 'width']: '100%',
-            [horizontal ? 'width' : 'height']: ctrl.springs.space,
+            [scrollHorizontal ? 'height' : 'width']: '100%',
+            [scrollHorizontal ? 'width' : 'height']: ctrl.springs.space,
             WebkitTransform: translate3d,
             msTransform: translate3d,
             transform: translate3d,

--- a/packages/parallax/src/index.tsx
+++ b/packages/parallax/src/index.tsx
@@ -24,6 +24,7 @@ export interface IParallaxLayer {
 
 export interface IParallax {
   config: ConfigProp
+  horizontal: boolean
   busy: boolean
   space: number
   offset: number
@@ -52,6 +53,9 @@ export const ParallaxLayer = React.memo(
     ({ horizontal, factor = 1, offset = 0, speed = 0, ...rest }, ref) => {
       // Our parent controls our height and position.
       const parent = useContext<IParallax>(ParentContext)
+
+      // Layer's horizontal defaults to parent's horizontal if not set.
+      if (horizontal === undefined) horizontal = parent.horizontal
 
       // This is how we animate.
       const ctrl = useMemoOne(() => {
@@ -155,6 +159,7 @@ export const Parallax = React.memo(
     const state: IParallax = useMemoOne(
       () => ({
         config,
+        horizontal,
         busy: false,
         space: 0,
         current: 0,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why
Currently, when `Parallax` has `horizontal={true}`, all `ParallaxLayer`s still translate vertically unless `horizontal={true}` is manually set on all of them. This change makes it so `ParallaxLayer`s' default `horizontal` matches `Parallax`'s.

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What
* Added `horizontal` to `IParallax` interface and `Parallax`'s `state`
* Added a check in `ParallaxLayer` to see if `horizontal === undefined` and reassign it if it is.
* Removed a CSS rule in sandbox demo that was causing numbers to appear too far to the left.
<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated: (Pending this being merged)
- [ ] Demo added: n/a
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

You can test this by looking at the sandbox demo "Parallax" (not vert). Currently, when you scroll horizontally, the layers still translate vertically.

This might be a breaking change if anyone is relying on this behavior, but it wouldn't affect anyone who has already manually set `horizontal` on `ParallaxLayer`s.

I will also submit a PR for the docs to add `horizontal` to `ParallaxLayer`'s prop list, but will wait until a decision is reached on this so I can accurately describe its behavior. I understand everyone is probably busy with v9 bug fixes, so if this is not a high priority right now, I'll just update the docs to reflect how it currently works.

<!-- feel free to add additional comments -->
