### PR TITLE
Fix: Ignore partial color names when interpolating strings.

### DIFF
--- a/packages/shared/src/createInterpolator.test.ts
+++ b/packages/shared/src/createInterpolator.test.ts
@@ -149,4 +149,13 @@ describe('Interpolation', () => {
 
     expect(interpolation(0.5)).toBe('rgba(2, 2, 2, 0.5)')
   })
+
+  it('should not match partial color names', () => {
+    const interpolation = createInterpolator({
+      range: [0, 1],
+      output: ['grayscale(0%)', 'grayscale(100%)'],
+    })
+
+    expect(interpolation(0.5)).toBe('grayscale(50%)')
+  })
 })

--- a/packages/shared/src/stringInterpolation.ts
+++ b/packages/shared/src/stringInterpolation.ts
@@ -36,8 +36,10 @@ export const createStringInterpolator = (
 ) => {
   if (!namedColorRegex)
     namedColorRegex = G.colors
-      ? new RegExp(`(${Object.keys(G.colors).join('|')})`, 'g')
-      : /^\b$/ // never match
+      ? // match color names, ignore partial matches
+        new RegExp(`(?<!\\w)(${Object.keys(G.colors).join('|')})(?!\\w)`, 'g')
+      : // never match
+        /^\b$/
 
   // Convert colors to rgba(...)
   const output = config.output.map(value =>

--- a/packages/shared/src/stringInterpolation.ts
+++ b/packages/shared/src/stringInterpolation.ts
@@ -37,7 +37,7 @@ export const createStringInterpolator = (
   if (!namedColorRegex)
     namedColorRegex = G.colors
       ? // match color names, ignore partial matches
-        new RegExp(`(?<!\\w)(${Object.keys(G.colors).join('|')})(?!\\w)`, 'g')
+        new RegExp(`(${Object.keys(G.colors).join('|')})(?!\\w)`, 'g')
       : // never match
         /^\b$/
 


### PR DESCRIPTION
### Why?

This PR prevents strings like `grayscale` from being interpolated as `gray` and `scale` (color & range). This is seen in #1452.

Here's their sandbox but with this fix: https://codesandbox.io/s/grayscale-demo-react-spring-mq1wl.

### What?

I updated the regex in the shared string interpolator to ignore color names that are immediately followed by alphanumerical characters.

Previously, I had this also check preceding characters, but I couldn't find a use-case for this, and the regex for that [isn't well supported](https://caniuse.com/js-regexp-lookbehind).

### Checklist

- ~~Documentation updated~~
- ~~Demo added~~
- [x] Ready to be merged
