### PR TITLE
[fix] useTransition ref handling

### DIFF
--- a/demo/src/sandboxes/simple-transition/src/App.tsx
+++ b/demo/src/sandboxes/simple-transition/src/App.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useCallback, CSSProperties } from 'react'
-import { useTransition, animated, AnimatedProps } from '@react-spring/web'
+import React, { useState, useCallback, CSSProperties, useEffect } from 'react'
+import { useTransition, animated, AnimatedProps, useSpringRef } from '@react-spring/web'
 
 import styles from './styles.module.css'
 
@@ -12,12 +12,17 @@ const pages: ((props: AnimatedProps<{ style: CSSProperties }>) => React.ReactEle
 export default function App() {
   const [index, set] = useState(0)
   const onClick = useCallback(() => set(state => (state + 1) % 3), [])
+  const transRef = useSpringRef()
   const transitions = useTransition(index, {
+    ref: transRef,
     keys: null,
     from: { opacity: 0, transform: 'translate3d(100%,0,0)' },
     enter: { opacity: 1, transform: 'translate3d(0%,0,0)' },
     leave: { opacity: 0, transform: 'translate3d(-50%,0,0)' },
   })
+  useEffect(() => {
+    transRef.start()
+  }, [index])
   return (
     <div className={`flex fill ${styles.container}`} onClick={onClick}>
       {transitions((style, i) => {

--- a/packages/core/src/hooks/useTransition.test.tsx
+++ b/packages/core/src/hooks/useTransition.test.tsx
@@ -128,6 +128,25 @@ describe('useTransition', () => {
     expect(ref.current).toHaveLength(3)
   })
 
+  it('returns a ref if the props argument is a function', () => {
+    let transRef: SpringRef | null = null
+    const update = createUpdater(({ args }) => {
+      const [transition, ref] = useTransition(...args)
+      rendered = transition((_, item) => item).props.children
+      transRef = ref
+      return null
+    })
+
+    update(true, () => ({
+      from: { n: 0 },
+      enter: { n: 1 },
+      leave: { n: 0 },
+    }))
+
+    expect(rendered).toEqual([true])
+
+    expect(transRef).toBeInstanceOf(SpringRef)
+  })
 })
 
 function createUpdater(
@@ -138,7 +157,7 @@ function createUpdater(
     result = undefined
   })
 
-  type Args = [any, UseTransitionProps, any[]?]
+  type Args = [any, UseTransitionProps | (() => UseTransitionProps), any[]?]
   return (...args: Args) => {
     const elem = <Component args={args} />
     if (result) result.rerender(elem)

--- a/packages/core/src/hooks/useTransition.test.tsx
+++ b/packages/core/src/hooks/useTransition.test.tsx
@@ -4,6 +4,7 @@ import { RenderResult, render } from '@testing-library/react'
 import { toArray } from '@react-spring/shared'
 import { TransitionFn, UseTransitionProps } from '../types'
 import { useTransition } from './useTransition'
+import { SpringRef } from '../SpringRef'
 
 describe('useTransition', () => {
   let transition: TransitionFn
@@ -114,6 +115,19 @@ describe('useTransition', () => {
       expect(rendered).toEqual([false])
     })
   })
+
+  it('assign controllers to provided "ref"', async () => {
+    const ref = new SpringRef()
+    const props = {
+      ref,
+    }
+    const children = [<div />, <div />, <div />]
+
+    update(children, props)
+
+    expect(ref.current).toHaveLength(3)
+  })
+
 })
 
 function createUpdater(

--- a/packages/core/src/hooks/useTransition.tsx
+++ b/packages/core/src/hooks/useTransition.tsx
@@ -199,6 +199,7 @@ export function useTransition(
     // The payload is used to update the spring props once the current render is committed.
     const payload: ControllerUpdate<UnknownProps> = {
       ...defaultProps,
+      ref: props.ref,
       delay: (delay += trail),
       // This prevents implied resets.
       reset: false,

--- a/packages/core/src/hooks/useTransition.tsx
+++ b/packages/core/src/hooks/useTransition.tsx
@@ -40,6 +40,16 @@ declare function clearTimeout(timeoutId: number): void
 
 export function useTransition<Item, Props extends object>(
   data: OneOrMore<Item>,
+  props: () =>
+    | UseTransitionProps<Item>
+    | (Props & Valid<Props, UseTransitionProps<Item>>),
+  deps?: any[]
+): PickAnimated<Props> extends infer State
+  ? [TransitionFn<Item, PickAnimated<Props>>, SpringRef<State>]
+  : never
+
+export function useTransition<Item, Props extends object>(
+  data: OneOrMore<Item>,
   props:
     | UseTransitionProps<Item>
     | (Props & Valid<Props, UseTransitionProps<Item>>)
@@ -57,14 +67,24 @@ export function useTransition<Item, Props extends object>(
 
 export function useTransition(
   data: unknown,
-  props: UseTransitionProps,
+  props: UseTransitionProps | (() => any),
   deps?: any[]
 ): any {
-  const { reset, sort, trail = 0, expires = true, onDestroyed } = props
+  const propsFn = is.fun(props) && props
+
+  const {
+    reset,
+    sort,
+    trail = 0,
+    expires = true,
+    onDestroyed,
+    ref: propsRef,
+    config: propsConfig,
+  }: UseTransitionProps<any> = propsFn ? propsFn() : props
 
   // Return a `SpringRef` if a deps array was passed.
   const ref = useMemo(
-    () => (arguments.length == 3 ? new SpringRef() : void 0),
+    () => (propsFn || arguments.length == 3 ? new SpringRef() : void 0),
     []
   )
 
@@ -94,7 +114,7 @@ export function useTransition(
   // The `key` prop can be undefined (which means the items themselves are used
   // as keys), or a function (which maps each item to its key), or an array of
   // keys (which are assigned to each item by index).
-  const keys = getKeys(items, props, prevTransitions)
+  const keys = getKeys(items, propsFn ? propsFn() : props, prevTransitions)
 
   // Expired transitions that need clean up.
   const expired = (reset && usedTransitions.current) || []
@@ -137,12 +157,13 @@ export function useTransition(
   // and ensure leaving transitions are rendered until they finish.
   if (reused.length) {
     let i = -1
+    const { leave }: UseTransitionProps<any> = propsFn ? propsFn() : props
     each(reused, (keyIndex, prevIndex) => {
       const t = prevTransitions![prevIndex]
       if (~keyIndex) {
         i = transitions.indexOf(t)
         transitions[i] = { ...t, item: items[keyIndex] }
-      } else if (props.leave) {
+      } else if (leave) {
         transitions.splice(++i, 0, t)
       }
     })
@@ -166,22 +187,24 @@ export function useTransition(
     const key = t.key
     const prevPhase = t.phase
 
+    const p: UseTransitionProps<any> = propsFn ? propsFn() : props
+
     let to: TransitionTo<any>
     let phase: TransitionPhase
     if (prevPhase == TransitionPhase.MOUNT) {
-      to = props.enter
+      to = p.enter
       phase = TransitionPhase.ENTER
     } else {
       const isLeave = keys.indexOf(key) < 0
       if (prevPhase != TransitionPhase.LEAVE) {
         if (isLeave) {
-          to = props.leave
+          to = p.leave
           phase = TransitionPhase.LEAVE
-        } else if ((to = props.update)) {
+        } else if ((to = p.update)) {
           phase = TransitionPhase.UPDATE
         } else return
       } else if (!isLeave) {
-        to = props.enter
+        to = p.enter
         phase = TransitionPhase.ENTER
       } else return
     }
@@ -192,14 +215,14 @@ export function useTransition(
     to = is.obj(to) ? inferTo(to) : { to }
 
     if (!to.config) {
-      const config = props.config || defaultProps.config
+      const config = propsConfig || defaultProps.config
       to.config = callProp(config, t.item, i, phase)
     }
 
     // The payload is used to update the spring props once the current render is committed.
     const payload: ControllerUpdate<UnknownProps> = {
       ...defaultProps,
-      ref: props.ref,
+      ref: propsRef,
       delay: (delay += trail),
       // This prevents implied resets.
       reset: false,
@@ -208,11 +231,11 @@ export function useTransition(
     }
 
     if (phase == TransitionPhase.ENTER && is.und(payload.from)) {
+      const p = propsFn ? propsFn() : props
       // The `initial` prop is used on the first render of our parent component,
       // as well as when `reset: true` is passed. It overrides the `from` prop
       // when defined, and it makes `enter` instant when null.
-      const from =
-        is.und(props.initial) || prevTransitions ? props.from : props.initial
+      const from = is.und(p.initial) || prevTransitions ? p.from : p.initial
 
       payload.from = callProp(from, t.item, i)
     }
@@ -285,22 +308,29 @@ export function useTransition(
         const { ctrl } = t
         t.phase = phase
 
-        // Attach the controller to our local ref.
-        ref?.add(ctrl)
-
-        // Update the injected ref if needed.
-        replaceRef(ctrl, payload.ref)
-
         // Save any springs created this render.
         setSprings(ctrl, springs)
+
+        // Attach the controller to our local ref.
+        ref?.add(ctrl)
 
         // Merge the context into new items.
         if (hasContext && phase == TransitionPhase.ENTER) {
           ctrl.start({ default: context })
         }
 
-        // Postpone the update if an injected ref exists.
-        ctrl[ctrl.ref ? 'update' : 'start'](payload)
+        if (payload) {
+          // Update the injected ref if needed.
+          replaceRef(ctrl, payload.ref)
+
+          // When an injected ref exists, the update is postponed
+          // until the ref has its `start` method called.
+          if (ctrl.ref) {
+            ctrl.update(payload)
+          } else {
+            ctrl.start(payload)
+          }
+        }
       })
     },
     reset ? void 0 : deps


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

`useTransition` was not passing its ref as part of the payload, this the controllers (each item has a controller) were not being attached. This caused failures in instances such as useChain. 

This resolves #1453 

### What

<!-- what have you done, if its a bug, whats your solution? -->

Pass the ref as part of the payload. However, when passing a ref, transitions will not be called unless `ref.start` is called, this is important and an example of what this looks like can be seen here: https://codesandbox.io/s/goofy-allen-u4hml?file=/src/App.tsx

I've also added the same API pattern that `useSprings` has, where only supplying a function as a prop argument will return a ref like so:

```js
const [transition, transApi] = useTransition(items, () => ({ ...props }))
```

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated – we're going on to beta so won't do yet.
- [x] Demo added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
