### PR TITLE
[Fix] csp issue

### DIFF
--- a/demo/src/sandboxes/card/src/App.tsx
+++ b/demo/src/sandboxes/card/src/App.tsx
@@ -44,17 +44,17 @@ export default function App() {
   useGesture(
     {
       onDrag: ({ active, offset: [x, y] }) =>
-        api.start({ x, y, rotateX: 0, rotateY: 0, scale: active ? 1 : 1.1 }),
-      onPinch: ({ offset: [d, a] }) => api.start({ zoom: d / 200, rotateZ: a }),
+        api({ x, y, rotateX: 0, rotateY: 0, scale: active ? 1 : 1.1 }),
+      onPinch: ({ offset: [d, a] }) => api({ zoom: d / 200, rotateZ: a }),
       onMove: ({ xy: [px, py], dragging }) =>
         !dragging &&
-        api.start({
+        api({
           rotateX: calcX(py, y.get()),
           rotateY: calcY(px, x.get()),
           scale: 1.1,
         }),
       onHover: ({ hovering }) =>
-        !hovering && api.start({ rotateX: 0, rotateY: 0, scale: 1 }),
+        !hovering && api({ rotateX: 0, rotateY: 0, scale: 1 }),
       onWheel: ({ event, offset: [, y] }) => {
         event.preventDefault()
         wheelApi.set({ wheelY: y })

--- a/packages/core/src/Controller.ts
+++ b/packages/core/src/Controller.ts
@@ -14,7 +14,7 @@ import {
 
 import { getDefaultProp } from './helpers'
 import { FrameValue } from './FrameValue'
-import { SpringRef } from './SpringRef'
+import type { SpringRef } from './SpringRef'
 import { SpringValue, createLoopUpdate, createUpdate } from './SpringValue'
 import { getCancelledResult, getCombinedResult } from './AnimationResult'
 import { runAsync, RunAsyncState, stopAsync } from './runAsync'

--- a/packages/core/src/SpringRef.ts
+++ b/packages/core/src/SpringRef.ts
@@ -21,7 +21,10 @@ export class SpringRef<State extends Lookup = Lookup> extends Function {
   readonly current: Controller<State>[] = []
 
   constructor() {
-    super('return arguments.callee._call.apply(arguments.callee, arguments)')
+    super()
+    return new Proxy(this, {
+      apply: (target, thisArg, args) => target._call(...args),
+    })
   }
 
   /** @deprecated use the property 'start' instead */

--- a/packages/core/src/SpringRef.ts
+++ b/packages/core/src/SpringRef.ts
@@ -7,93 +7,17 @@ interface ControllerUpdateFn<State extends Lookup = Lookup> {
   (i: number, ctrl: Controller<State>): ControllerUpdate<State> | Falsy
 }
 
-export class SpringRef<State extends Lookup = Lookup> {
-  readonly current: Controller<State>[] = []
-
-  /** Update the state of each controller without animating. */
-  set(values: Partial<State>) {
-    each(this.current, ctrl => ctrl.set(values))
-  }
-
-  /** Start the queued animations of each controller. */
-  start(): AsyncResult<Controller<State>>[]
-  /** Update every controller with the same props. */
-  start(props: ControllerUpdate<State>): AsyncResult<Controller<State>>[]
-  /** Update controllers based on their state. */
-  start(props: ControllerUpdateFn<State>): AsyncResult<Controller<State>>[]
-  /** Start animating each controller. */
-  start(
-    props?: ControllerUpdate<State> | ControllerUpdateFn<State>
-  ): AsyncResult<Controller<State>>[]
-  /** @internal */
-  start(props?: object | ControllerUpdateFn<State>) {
-    const results: AsyncResult[] = []
-
-    each(this.current, (ctrl, i) => {
-      if (is.und(props)) {
-        results.push(ctrl.start())
-      } else {
-        const update = this._getProps(props, ctrl, i)
-        if (update) {
-          results.push(ctrl.start(update))
-        }
-      }
-    })
-
-    return results
-  }
-
-  /** Add the same props to each controller's update queue. */
-  update(props: ControllerUpdate<State>): this
-  /** Generate separate props for each controller's update queue. */
-  update(props: ControllerUpdateFn<State>): this
-  /** Add props to each controller's update queue. */
-  update(props: ControllerUpdate<State> | ControllerUpdateFn<State>): this
-  /** @internal */
-  update(props: object | ControllerUpdateFn<State>) {
-    each(this.current, (ctrl, i) => ctrl.update(this._getProps(props, ctrl, i)))
-    return this
-  }
-
-  /** Add a controller to this ref */
-  add(ctrl: Controller<State>) {
-    if (!this.current.includes(ctrl)) {
-      this.current.push(ctrl)
-    }
-  }
-
-  /** Remove a controller from this ref */
-  delete(ctrl: Controller<State>) {
-    const i = this.current.indexOf(ctrl)
-    if (~i) this.current.splice(i, 1)
-  }
-
-  /** Overridden by `useTrail` to manipulate props */
-  protected _getProps(
-    arg: ControllerUpdate<State> | ControllerUpdateFn<State>,
-    ctrl: Controller<State>,
-    index: number
-  ): ControllerUpdate<State> | Falsy {
-    return is.fun(arg) ? arg(index, ctrl) : arg
-  }
-}
-
-export interface SpringRef<State extends Lookup> {
+export interface SpringRef<State extends Lookup = Lookup> {
   (props?: ControllerUpdate<State> | ControllerUpdateFn<State>): AsyncResult<
     Controller<State>
   >[]
-  /** Stop all animations. */
-  stop(): this
-  /** Stop animations for the given keys. */
-  stop(keys: OneOrMore<string>): this
-  /** Cancel all animations. */
-  stop(cancel: boolean): this
-  /** Cancel animations for the given keys. */
-  stop(cancel: boolean, keys: OneOrMore<string>): this
-  /** Stop some or all animations. */
-  stop(keys?: OneOrMore<string>): this
-  /** Cancel some or all animations. */
-  stop(cancel: boolean, keys?: OneOrMore<string>): this
+  current: Controller<State>[]
+
+  /** Add a controller to this ref */
+  add(ctrl: Controller<State>): void
+
+  /** Remove a controller from this ref */
+  delete(ctrl: Controller<State>): void
 
   /** Pause all animations. */
   pause(): this
@@ -108,34 +32,144 @@ export interface SpringRef<State extends Lookup> {
   resume(keys: OneOrMore<string>): this
   /** Resume some or all animations. */
   resume(keys?: OneOrMore<string>): this
+
+  /** Update the state of each controller without animating. */
+  set(values: Partial<State>): void
+
+  /** Start the queued animations of each controller. */
+  start(): AsyncResult<Controller<State>>[]
+  /** Update every controller with the same props. */
+  start(props: ControllerUpdate<State>): AsyncResult<Controller<State>>[]
+  /** Update controllers based on their state. */
+  start(props: ControllerUpdateFn<State>): AsyncResult<Controller<State>>[]
+  /** Start animating each controller. */
+  start(
+    props?: ControllerUpdate<State> | ControllerUpdateFn<State>
+  ): AsyncResult<Controller<State>>[]
+
+  /** Stop all animations. */
+  stop(): this
+  /** Stop animations for the given keys. */
+  stop(keys: OneOrMore<string>): this
+  /** Cancel all animations. */
+  stop(cancel: boolean): this
+  /** Cancel animations for the given keys. */
+  stop(cancel: boolean, keys: OneOrMore<string>): this
+  /** Stop some or all animations. */
+  stop(keys?: OneOrMore<string>): this
+  /** Cancel some or all animations. */
+  stop(cancel: boolean, keys?: OneOrMore<string>): this
+
+  /** Add the same props to each controller's update queue. */
+  update(props: ControllerUpdate<State>): this
+  /** Generate separate props for each controller's update queue. */
+  update(props: ControllerUpdateFn<State>): this
+  /** Add props to each controller's update queue. */
+  update(props: ControllerUpdate<State> | ControllerUpdateFn<State>): this
+
+  _getProps(
+    arg: ControllerUpdate<State> | ControllerUpdateFn<State>,
+    ctrl: Controller<State>,
+    index: number
+  ): ControllerUpdate<State> | Falsy
 }
 
-/**
- * TODO(tree-shaking): this is probably a cause for concern
- * It could just be written in.
- */
-each(['stop', 'pause', 'resume'] as const, key => {
-  SpringRef.prototype[key] = function (this: SpringRef) {
-    each(this.current, ctrl => ctrl[key](...arguments))
-    return this
-  } as any
-})
+export const SpringRef = <
+  State extends Lookup = Lookup
+>(): SpringRef<State> => {
+  const current: Controller<State>[] = []
 
-export function CallableSpringRef() {
-  const ref = new SpringRef()
-
-  // @ts-ignore
-  const call: SpringRef = (...args) => {
+  const SpringRef: SpringRef<State> = function (props) {
     deprecateDirectCall()
-    ref.start(...args)
+
+    const results: AsyncResult[] = []
+
+    each(current, (ctrl, i) => {
+      if (is.und(props)) {
+        results.push(ctrl.start())
+      } else {
+        const update = _getProps(props, ctrl, i)
+        if (update) {
+          results.push(ctrl.start(update))
+        }
+      }
+    })
+
+    return results
   }
 
-  Object.getOwnPropertyNames(Object.getPrototypeOf(ref)).forEach(key => {
-    // @ts-expect-error
-    call.current = ref.current
-    // @ts-expect-error
-    call[key] = ref[key]
-  })
+  SpringRef.current = current
 
-  return call
+  /** Add a controller to this ref */
+  SpringRef.add = function (ctrl: Controller<State>) {
+    if (!current.includes(ctrl)) {
+      current.push(ctrl)
+    }
+  }
+
+  /** Remove a controller from this ref */
+  SpringRef.delete = function (ctrl: Controller<State>) {
+    const i = current.indexOf(ctrl)
+    if (~i) current.splice(i, 1)
+  }
+
+  /** Pause all animations. */
+  SpringRef.pause = function () {
+    each(current, ctrl => ctrl.pause(...arguments))
+    return this
+  }
+
+  /** Resume all animations. */
+  SpringRef.resume = function () {
+    each(current, ctrl => ctrl.resume(...arguments))
+    return this
+  }
+
+  /** Update the state of each controller without animating. */
+  SpringRef.set = function (values: Partial<State>) {
+    each(current, ctrl => ctrl.set(values))
+  }
+
+  /** @internal */
+  SpringRef.start = function (props?: object | ControllerUpdateFn<State>) {
+    const results: AsyncResult[] = []
+
+    each(current, (ctrl, i) => {
+      if (is.und(props)) {
+        results.push(ctrl.start())
+      } else {
+        const update = this._getProps(props, ctrl, i)
+        if (update) {
+          results.push(ctrl.start(update))
+        }
+      }
+    })
+
+    return results
+  }
+
+  /** Stop all animations. */
+  SpringRef.stop = function () {
+    each(current, ctrl => ctrl.stop(...arguments))
+    return this
+  }
+
+  /** @internal */
+  SpringRef.update = function (props: object | ControllerUpdateFn<State>) {
+    each(current, (ctrl, i) => ctrl.update(this._getProps(props, ctrl, i)))
+    return this
+  }
+
+  /** Overridden by `useTrail` to manipulate props */
+  const _getProps = function (
+    arg: ControllerUpdate<State> | ControllerUpdateFn<State>,
+    ctrl: Controller<State>,
+    index: number
+  ): ControllerUpdate<State> | Falsy {
+    return is.fun(arg) ? arg(index, ctrl) : arg
+  }
+
+  SpringRef._getProps = _getProps
+
+  return SpringRef
 }

--- a/packages/core/src/hooks/useSpring.test.tsx
+++ b/packages/core/src/hooks/useSpring.test.tsx
@@ -74,7 +74,11 @@ describe('useSpring', () => {
     })
     it('returns a ref', () => {
       update({ x: 0 }, [1])
-      expect(ref).toBeInstanceOf(SpringRef)
+      /**
+       * this should be reinstanted once we have removed CallableSpringRef
+       */
+      // expect(ref).toBeInstanceOf(SpringRef)
+      expect(ref).toHaveProperty('start')
     })
   })
 
@@ -88,7 +92,11 @@ describe('useSpring', () => {
     })
     it('returns a ref', () => {
       update(() => ({ x: 0 }))
-      expect(ref).toBeInstanceOf(SpringRef)
+      /**
+       * this should be reinstanted once we have removed CallableSpringRef
+       */
+      // expect(ref).toBeInstanceOf(SpringRef)
+      expect(ref).toHaveProperty('start')
     })
   })
 
@@ -105,7 +113,11 @@ describe('useSpring', () => {
     })
     it('returns a ref', () => {
       update(() => ({ x: 0 }), [1])
-      expect(ref).toBeInstanceOf(SpringRef)
+      /**
+       * this should be reinstanted once we have removed CallableSpringRef
+       */
+      // expect(ref).toBeInstanceOf(SpringRef)
+      expect(ref).toHaveProperty('start')
     })
   })
 })

--- a/packages/core/src/hooks/useSpring.test.tsx
+++ b/packages/core/src/hooks/useSpring.test.tsx
@@ -74,11 +74,7 @@ describe('useSpring', () => {
     })
     it('returns a ref', () => {
       update({ x: 0 }, [1])
-      /**
-       * this should be reinstanted once we have removed CallableSpringRef
-       */
-      // expect(ref).toBeInstanceOf(SpringRef)
-      expect(ref).toHaveProperty('start')
+      testIsRef(ref)
     })
   })
 
@@ -92,11 +88,7 @@ describe('useSpring', () => {
     })
     it('returns a ref', () => {
       update(() => ({ x: 0 }))
-      /**
-       * this should be reinstanted once we have removed CallableSpringRef
-       */
-      // expect(ref).toBeInstanceOf(SpringRef)
-      expect(ref).toHaveProperty('start')
+      testIsRef(ref)
     })
   })
 
@@ -113,11 +105,7 @@ describe('useSpring', () => {
     })
     it('returns a ref', () => {
       update(() => ({ x: 0 }), [1])
-      /**
-       * this should be reinstanted once we have removed CallableSpringRef
-       */
-      // expect(ref).toBeInstanceOf(SpringRef)
-      expect(ref).toHaveProperty('start')
+      testIsRef(ref)
     })
   })
 })
@@ -163,4 +151,19 @@ function createUpdater(Component: React.ComponentType<{ args: [any, any?] }>) {
     renderWithContext((prevElem = <Component args={args} />))
 
   return [update, context] as const
+}
+
+function testIsRef(ref: SpringRef | null) {
+  const props = [
+    'add',
+    'delete',
+    'pause',
+    'resume',
+    'set',
+    'start',
+    'stop',
+    'update',
+    '_getProps',
+  ]
+  props.forEach(prop => expect(ref).toHaveProperty(prop))
 }

--- a/packages/core/src/hooks/useSpringRef.ts
+++ b/packages/core/src/hooks/useSpringRef.ts
@@ -1,8 +1,9 @@
 import { useState } from 'react'
 import { Lookup } from '@react-spring/types'
 import { SpringRef } from '../SpringRef'
+import type { SpringRef as SpringRefType } from '../SpringRef'
 
-const initSpringRef = () => new SpringRef<any>()
+const initSpringRef = () => SpringRef<any>()
 
 export const useSpringRef = <State extends Lookup = Lookup>() =>
-  useState(initSpringRef)[0] as SpringRef<State>
+  useState(initSpringRef)[0] as SpringRefType<State>

--- a/packages/core/src/hooks/useSprings.ts
+++ b/packages/core/src/hooks/useSprings.ts
@@ -25,11 +25,12 @@ import {
 } from '../Controller'
 import { hasProps, detachRefs, replaceRef } from '../helpers'
 import { SpringContext } from '../SpringContext'
-import { SpringRef, CallableSpringRef } from '../SpringRef'
+import { SpringRef } from '../SpringRef'
+import type { SpringRef as SpringRefType } from '../SpringRef'
 
 export type UseSpringsProps<State extends Lookup = Lookup> = unknown &
   ControllerUpdate<State> & {
-    ref?: SpringRef<State>
+    ref?: SpringRefType<State>
   }
 
 /**
@@ -43,7 +44,7 @@ export function useSprings<Props extends UseSpringProps>(
   props: (i: number, ctrl: Controller) => Props,
   deps?: readonly any[]
 ): PickAnimated<Props> extends infer State
-  ? [SpringValues<State>[], SpringRef<State>]
+  ? [SpringValues<State>[], SpringRefType<State>]
   : never
 
 /**
@@ -62,7 +63,7 @@ export function useSprings<Props extends UseSpringsProps>(
   props: Props[] & UseSpringsProps<PickAnimated<Props>>[],
   deps: readonly any[] | undefined
 ): PickAnimated<Props> extends infer State
-  ? [SpringValues<State>[], SpringRef<State>]
+  ? [SpringValues<State>[], SpringRefType<State>]
   : never
 
 /** @internal */
@@ -76,7 +77,7 @@ export function useSprings(
 
   // Create a local ref if a props function or deps array is ever passed.
   const ref = useMemo(
-    () => (propsFn || arguments.length == 3 ? CallableSpringRef() : void 0),
+    () => (propsFn || arguments.length == 3 ? SpringRef() : void 0),
     []
   )
 

--- a/packages/core/src/hooks/useSprings.ts
+++ b/packages/core/src/hooks/useSprings.ts
@@ -25,7 +25,7 @@ import {
 } from '../Controller'
 import { hasProps, detachRefs, replaceRef } from '../helpers'
 import { SpringContext } from '../SpringContext'
-import { SpringRef } from '../SpringRef'
+import { SpringRef, CallableSpringRef } from '../SpringRef'
 
 export type UseSpringsProps<State extends Lookup = Lookup> = unknown &
   ControllerUpdate<State> & {
@@ -76,7 +76,7 @@ export function useSprings(
 
   // Create a local ref if a props function or deps array is ever passed.
   const ref = useMemo(
-    () => (propsFn || arguments.length == 3 ? new SpringRef() : void 0),
+    () => (propsFn || arguments.length == 3 ? CallableSpringRef() : void 0),
     []
   )
 

--- a/packages/core/src/hooks/useTransition.test.tsx
+++ b/packages/core/src/hooks/useTransition.test.tsx
@@ -117,7 +117,7 @@ describe('useTransition', () => {
   })
 
   it('assign controllers to provided "ref"', async () => {
-    const ref = new SpringRef()
+    const ref = SpringRef()
     const props = {
       ref,
     }

--- a/packages/core/src/hooks/useTransition.test.tsx
+++ b/packages/core/src/hooks/useTransition.test.tsx
@@ -126,6 +126,8 @@ describe('useTransition', () => {
     update(children, props)
 
     expect(ref.current).toHaveLength(3)
+
+    testIsRef(ref)
   })
 
   it('returns a ref if the props argument is a function', () => {
@@ -145,11 +147,7 @@ describe('useTransition', () => {
 
     expect(rendered).toEqual([true])
 
-    /**
-     * this should be reinstanted once we have removed CallableSpringRef
-     */
-    // expect(transRef).toHaveProperty(SpringRef)
-    expect(transRef).toHaveProperty('start')
+    testIsRef(transRef)
   })
 })
 
@@ -168,4 +166,19 @@ function createUpdater(
     else result = render(elem)
     return result
   }
+}
+
+function testIsRef(ref: SpringRef | null) {
+  const props = [
+    'add',
+    'delete',
+    'pause',
+    'resume',
+    'set',
+    'start',
+    'stop',
+    'update',
+    '_getProps',
+  ]
+  props.forEach(prop => expect(ref).toHaveProperty(prop))
 }

--- a/packages/core/src/hooks/useTransition.test.tsx
+++ b/packages/core/src/hooks/useTransition.test.tsx
@@ -145,7 +145,11 @@ describe('useTransition', () => {
 
     expect(rendered).toEqual([true])
 
-    expect(transRef).toBeInstanceOf(SpringRef)
+    /**
+     * this should be reinstanted once we have removed CallableSpringRef
+     */
+    // expect(transRef).toHaveProperty(SpringRef)
+    expect(transRef).toHaveProperty('start')
   })
 })
 

--- a/packages/core/src/hooks/useTransition.tsx
+++ b/packages/core/src/hooks/useTransition.tsx
@@ -32,7 +32,8 @@ import {
 } from '../helpers'
 import { Controller, getSprings, setSprings } from '../Controller'
 import { SpringContext } from '../SpringContext'
-import { SpringRef, CallableSpringRef } from '../SpringRef'
+import { SpringRef } from '../SpringRef'
+import type { SpringRef as SpringRefType } from '../SpringRef'
 import { TransitionPhase } from '../TransitionPhase'
 
 declare function setTimeout(handler: Function, timeout?: number): number
@@ -45,7 +46,7 @@ export function useTransition<Item, Props extends object>(
     | (Props & Valid<Props, UseTransitionProps<Item>>),
   deps?: any[]
 ): PickAnimated<Props> extends infer State
-  ? [TransitionFn<Item, PickAnimated<Props>>, SpringRef<State>]
+  ? [TransitionFn<Item, PickAnimated<Props>>, SpringRefType<State>]
   : never
 
 export function useTransition<Item, Props extends object>(
@@ -62,7 +63,7 @@ export function useTransition<Item, Props extends object>(
     | (Props & Valid<Props, UseTransitionProps<Item>>),
   deps: any[] | undefined
 ): PickAnimated<Props> extends infer State
-  ? [TransitionFn<Item, State>, SpringRef<State>]
+  ? [TransitionFn<Item, State>, SpringRefType<State>]
   : never
 
 export function useTransition(
@@ -84,7 +85,7 @@ export function useTransition(
 
   // Return a `SpringRef` if a deps array was passed.
   const ref = useMemo(
-    () => (propsFn || arguments.length == 3 ? CallableSpringRef() : void 0),
+    () => (propsFn || arguments.length == 3 ? SpringRef() : void 0),
     []
   )
 

--- a/packages/core/src/hooks/useTransition.tsx
+++ b/packages/core/src/hooks/useTransition.tsx
@@ -32,7 +32,7 @@ import {
 } from '../helpers'
 import { Controller, getSprings, setSprings } from '../Controller'
 import { SpringContext } from '../SpringContext'
-import { SpringRef } from '../SpringRef'
+import { SpringRef, CallableSpringRef } from '../SpringRef'
 import { TransitionPhase } from '../TransitionPhase'
 
 declare function setTimeout(handler: Function, timeout?: number): number
@@ -84,7 +84,7 @@ export function useTransition(
 
   // Return a `SpringRef` if a deps array was passed.
   const ref = useMemo(
-    () => (propsFn || arguments.length == 3 ? new SpringRef() : void 0),
+    () => (propsFn || arguments.length == 3 ? CallableSpringRef() : void 0),
     []
   )
 

--- a/packages/shared/src/deprecations.ts
+++ b/packages/shared/src/deprecations.ts
@@ -28,6 +28,6 @@ export function deprecateInterpolate() {
 const warnDirectCall = once(console.warn)
 export function deprecateDirectCall() {
   warnDirectCall(
-    `${prefix}Directly calling start instead of using the api object is deprecated in v9 (use ".start" instead)`
+    `${prefix}Directly calling start instead of using the api object is deprecated in v9 (use ".start" instead), this will be removed in later 0.X.0 versions`
   )
 }

--- a/targets/web/src/types/__tests__/useSpring.tsx
+++ b/targets/web/src/types/__tests__/useSpring.tsx
@@ -147,7 +147,7 @@ test('imperative mode', () => {
 });
 
 test('spring refs', () => {
-  const ref = new SpringRef();
+  const ref = SpringRef();
   useSpring({ foo: 1, ref });
   ref.start();
   ref.stop(['foo', 'bar']);


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

To resolve #1423. In short the current way we're allowing people to call the `SpringRef` as they used to in v8 is to extend the `SpringRef` class from `Function` this creates issues with CSPs. Therefore we're at a fork in the road of implementing this PR, or simply removing the functionality earlier than expected.

### What

<!-- what have you done, if its a bug, whats your solution? -->

Currently i've created a wrap-around function named `CallbableSpringRef`. It should allow you to do:

```js
const [styles, start] = useSpring(() => ({
 from: { width: 0 },
 to: { width: 100 }
}))

start()
```

This keeps in line with a feature we brought back in `9.1.0` to ease people into the new v9 [imperative API](https://react-spring.io/common/imperatives-and-refs#api-methods). However this will be deprecated in the future.

It's a bit messy with the TS but I really do see this a bandaid to be removed sooner rather than later.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
