### PR TITLE
[Fix] springs sometimes return undefined

### DIFF
--- a/packages/core/src/Controller.ts
+++ b/packages/core/src/Controller.ts
@@ -442,7 +442,7 @@ export async function flushUpdate(
  * until they're given to `setSprings`.
  */
 export function getSprings<State extends Lookup>(
-  ctrl: Controller<State>,
+  ctrl: Controller<Lookup<any>>,
   props?: OneOrMore<ControllerUpdate<State>>
 ) {
   const springs = { ...ctrl.springs }
@@ -460,6 +460,7 @@ export function getSprings<State extends Lookup>(
       })
     })
   }
+  setSprings(ctrl, springs)
   return springs
 }
 
@@ -468,7 +469,7 @@ export function getSprings<State extends Lookup>(
  * whose key is not already in use.
  */
 export function setSprings(
-  ctrl: Controller,
+  ctrl: Controller<Lookup<any>>,
   springs: SpringValues<UnknownProps>
 ) {
   eachProp(springs, (spring, key) => {

--- a/packages/core/src/hooks/useSprings.ts
+++ b/packages/core/src/hooks/useSprings.ts
@@ -122,17 +122,17 @@ export function useSprings(
     []
   )
 
-  const ctrls = [...state.ctrls]
+  const ctrls = useRef([...state.ctrls])
   const updates: any[] = []
 
   // Cache old controllers to dispose in the commit phase.
   const prevLength = usePrev(length) || 0
-  const oldCtrls = ctrls.slice(length, prevLength)
+  const oldCtrls = ctrls.current.slice(length, prevLength)
 
   // Create new controllers when "length" increases, and destroy
   // the affected controllers when "length" decreases.
   useMemo(() => {
-    ctrls.length = length
+    ctrls.current.length = length
     declareUpdates(prevLength, length)
   }, [length])
 
@@ -144,7 +144,9 @@ export function useSprings(
   /** Fill the `updates` array with declarative updates for the given index range. */
   function declareUpdates(startIndex: number, endIndex: number) {
     for (let i = startIndex; i < endIndex; i++) {
-      const ctrl = ctrls[i] || (ctrls[i] = new Controller(null, state.flush))
+      const ctrl =
+        ctrls.current[i] ||
+        (ctrls.current[i] = new Controller(null, state.flush))
 
       const update: UseSpringProps<any> = propsFn
         ? propsFn(i, ctrl)
@@ -159,7 +161,7 @@ export function useSprings(
   // New springs are created during render so users can pass them to
   // their animated components, but new springs aren't cached until the
   // commit phase (see the `useLayoutEffect` callback below).
-  const springs = ctrls.map((ctrl, i) => getSprings(ctrl, updates[i]))
+  const springs = ctrls.current.map((ctrl, i) => getSprings(ctrl, updates[i]))
 
   const context = useContext(SpringContext)
   const prevContext = usePrev(context)
@@ -169,7 +171,7 @@ export function useSprings(
     layoutId.current++
 
     // Replace the cached controllers.
-    state.ctrls = ctrls
+    state.ctrls = ctrls.current
 
     // Flush the commit queue.
     const { queue } = state
@@ -189,6 +191,7 @@ export function useSprings(
       const values = springs[i]
       setSprings(ctrl, values)
 
+    each(ctrls.current, (ctrl, i) => {
       // Attach the controller to the local ref.
       ref?.add(ctrl)
 

--- a/packages/core/src/hooks/useSprings.ts
+++ b/packages/core/src/hooks/useSprings.ts
@@ -187,10 +187,6 @@ export function useSprings(
     })
 
     // Update existing controllers.
-    each(ctrls, (ctrl, i) => {
-      const values = springs[i]
-      setSprings(ctrl, values)
-
     each(ctrls.current, (ctrl, i) => {
       // Attach the controller to the local ref.
       ref?.add(ctrl)

--- a/packages/core/src/hooks/useTransition.tsx
+++ b/packages/core/src/hooks/useTransition.tsx
@@ -30,7 +30,7 @@ import {
   inferTo,
   replaceRef,
 } from '../helpers'
-import { Controller, getSprings, setSprings } from '../Controller'
+import { Controller, getSprings } from '../Controller'
 import { SpringContext } from '../SpringContext'
 import { SpringRef } from '../SpringRef'
 import { TransitionPhase } from '../TransitionPhase'
@@ -321,12 +321,9 @@ export function useTransition(
 
   useLayoutEffect(
     () => {
-      each(changes, ({ phase, springs, payload }, t) => {
+      each(changes, ({ phase, payload }, t) => {
         const { ctrl } = t
         t.phase = phase
-
-        // Save any springs created this render.
-        setSprings(ctrl, springs)
 
         // Attach the controller to our local ref.
         ref?.add(ctrl)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

resolves #1096 

### What

<!-- what have you done, if its a bug, whats your solution? -->

We attach our springs to the `Controller` in a useEffect hook however the life cycle of hooks means the `setState` hook is called before any `useLayoutEffect` or `useEffect` hooks are called so our `SpringValue`s are destroyed and lost never being added to the `Controller`.

Instead when we create springs, we attach them to the `Controller` immediately preserving them.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
