### PR TITLE
fix: update all values of animated array (#1430)

### DIFF
--- a/packages/animated/src/AnimatedArray.ts
+++ b/packages/animated/src/AnimatedArray.ts
@@ -28,7 +28,7 @@ export class AnimatedArray<
     const payload = this.getPayload()
     // Reuse the payload when lengths are equal.
     if (source.length == payload.length) {
-      return payload.some((node, i) => node.setValue(source[i]))
+      return payload.map((node, i) => node.setValue(source[i])).some(Boolean)
     }
     // Remake the payload when length changes.
     super.setValue(source.map(makeAnimated))

--- a/targets/web/src/animated.test.tsx
+++ b/targets/web/src/animated.test.tsx
@@ -139,6 +139,17 @@ describe('animated component', () => {
       'scale(2) translate(10px,20px) translate3d(30px,40px,50px)'
     )
   })
+  it('updates all values of Animated arrays', () => {
+    const translate3d = spring([10, 20, 30] as const)
+    const { queryByTestId } = render(
+      <a.div style={{ translate3d }} data-testid="wrapper" />
+    )
+    const wrapper: any = queryByTestId('wrapper')!
+    expect(wrapper.style.transform).toBe('translate3d(10px,20px,30px)')
+    translate3d.set([11, 21, 31] as const)
+    mockRaf.step()
+    expect(wrapper.style.transform).toBe('translate3d(11px,21px,31px)')
+  })
   it('sets default units to unit-less values passed as transform functions', () => {
     const { queryByTestId } = render(
       <a.div


### PR DESCRIPTION
### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->
Fixing bug https://github.com/pmndrs/react-spring/issues/1430

### What

<!-- what have you done, if its a bug, whats your solution? -->
Implemented suggested fix by a user in that thread, and wrote a unit test too.
I confirmed that the unit test failed in the expected way when the fix was not applied - i.e. spring of [10,20] is then updated to [11,21], but the resulting prop on animated div is still [11,20], because only the first animated value in the array was being updated.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Demo added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
