### PR TITLE
fix(support): incorrect type imports for rafz

### DIFF
--- a/packages/shared/src/globals.ts
+++ b/packages/shared/src/globals.ts
@@ -1,10 +1,9 @@
-import { raf } from '@react-spring/rafz'
+import { raf, Rafz } from '@react-spring/rafz'
 import {
   OneOrMore,
   InterpolatorConfig,
   InterpolatorArgs,
 } from '@react-spring/types'
-import { Rafz } from 'packages/rafz'
 
 import { FluidValue } from './fluids'
 import type { OpaqueAnimation } from './FrameLoop'


### PR DESCRIPTION
### Why

Fixes #1559 

### What

Import type declarations from `@react-spring/rafz` instead of `packages/rafz`

### Checklist


- Documentation updates: Not required
- Demo: Not needed
- Ready to be merged: Yes

