### PR TITLE
Fix issue 1582

### DIFF
--- a/packages/shared/src/helpers.ts
+++ b/packages/shared/src/helpers.ts
@@ -54,7 +54,9 @@ export function eachProp<T extends object, This>(
   ctx?: This
 ) {
   for (const key in obj) {
-    fn.call(ctx as any, obj[key] as any, key)
+    if (obj.hasOwnProperty(key)) {
+      fn.call(ctx as any, obj[key] as any, key)
+    }
   }
 }
 


### PR DESCRIPTION
### What

Fix issue [1582](https://github.com/pmndrs/react-spring/issues/1582)

### Why

[eachProp](https://github.com/pmndrs/react-spring/blob/26bd8f153dd9284915b6fbc2bc299320c44b593d/packages/shared/src/helpers.ts#L47) function accepts argument [primitives](https://github.com/pmndrs/react-spring/blob/26bd8f153dd9284915b6fbc2bc299320c44b593d/targets/web/src/primitives.ts#L2) which type is `Array`. 
Iteration works over `Array.prototype` and in case there is a `boolean` it throws an error. It should use only values from [primitives](https://github.com/pmndrs/react-spring/blob/26bd8f153dd9284915b6fbc2bc299320c44b593d/targets/web/src/primitives.ts#L2) and should not iterate over `Array.prototype`. 

<img width="1393" alt="Screen Shot 2021-06-24 at 15 17 23" src="https://user-images.githubusercontent.com/8538941/123255827-530d5b80-d501-11eb-957d-12d199c5ed25.png">


### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Demo added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
