### PR TITLE
fix: add `immediate` to payload in useTransition hook

### DIFF
--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -95,6 +95,7 @@ export const getDefaultProps = <T extends Lookup>(
  */
 export const DEFAULT_PROPS = [
   'config',
+  'immediate',
   'onProps',
   'onStart',
   'onChange',

--- a/packages/core/src/helpers.ts
+++ b/packages/core/src/helpers.ts
@@ -95,7 +95,6 @@ export const getDefaultProps = <T extends Lookup>(
  */
 export const DEFAULT_PROPS = [
   'config',
-  'immediate',
   'onProps',
   'onStart',
   'onChange',

--- a/packages/core/src/hooks/useTransition.test.tsx
+++ b/packages/core/src/hooks/useTransition.test.tsx
@@ -149,6 +149,23 @@ describe('useTransition', () => {
 
     testIsRef(transRef)
   })
+
+  it('passes immediate through to payload', async () => {
+    const props = {
+      from: { n: 0 },
+      enter: { n: 1 },
+      leave: { n: 0 },
+      immediate: true,
+    }
+
+    update(true, props)
+
+    transition(style => {
+      expect(style.n.animation.immediate).toEqual(true)
+
+      return null
+    })
+  })
 })
 
 function createUpdater(

--- a/packages/core/src/hooks/useTransition.tsx
+++ b/packages/core/src/hooks/useTransition.tsx
@@ -101,14 +101,15 @@ export function useTransition(
   })
 
   // Destroy all transitions on dismount.
-  useOnce(() => () =>
-    each(usedTransitions.current!, t => {
-      if (t.expired) {
-        clearTimeout(t.expirationId!)
-      }
-      detachRefs(t.ctrl, ref)
-      t.ctrl.stop(true)
-    })
+  useOnce(
+    () => () =>
+      each(usedTransitions.current!, t => {
+        if (t.expired) {
+          clearTimeout(t.expirationId!)
+        }
+        detachRefs(t.ctrl, ref)
+        t.ctrl.stop(true)
+      })
   )
 
   // Keys help with reusing transitions between renders.
@@ -242,6 +243,7 @@ export function useTransition(
       // we need to add our props.delay value you here.
       delay: propsDelay + delay,
       ref: propsRef,
+      immediate: p.immediate,
       // This prevents implied resets.
       reset: false,
       // Merge any phase-specific props.


### PR DESCRIPTION

### Why

This change does fix #1581. I'm not sure if this is the right change though, given the comment above the code.

### What

Add `immediate` back to the array of default props to allow `useTransition({ immediate: true })` to be respected again.

### Checklist

- [ ] Demo added
- [x] Ready to be merged

### Notes

If this is indeed a proper fix, I'd like to add a test somewhere. Any help with that would be great.