### PR TITLE
correct 'cancel-prop' link in props.mdx

### DIFF
--- a/docs/src/pages/common/props.mdx
+++ b/docs/src/pages/common/props.mdx
@@ -18,7 +18,7 @@ All primitives inherit the following properties (though some of them may bring t
 | [config](configs) | obj/fn            | Spring config (contains mass, tension, friction, etc). Also valid as a function for individual keys: key => config                                                       |
 | reset             | bool              | The spring starts to animate from scratch (from -> to) if set true                                                                                                       |
 | reverse           | bool              | "from" and "to" are switched if set true, this will only make sense in combination with the "reset" flag                                                                 |
-| cancel            | bool/string/fn    | When `true`, the `cancel` prop stops the animation of every animated value owned by the `Controller` that receives it. See [cancel prop](/#cancel-prop) for more details |
+| cancel            | bool/string/fn    | When `true`, the `cancel` prop stops the animation of every animated value owned by the `Controller` that receives it. See [cancel prop](#cancel-prop) for more details |
 | pause             | bool              | The `pause` prop literally freezes animations in time.                                                                                                                   |
 | `events`          | fn                | A variety of event callbacks (see [events](#events) for more information)                                                                                                |
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why
the 'cancel-prop' link is not 'correct' which will take to the index page.  
https://react-spring.io/common/props

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What
change the link from  '/#cancel-prop' to '#cancel-prop'
<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Demo added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
