### PR TITLE
fix: resolve #1642 Notification Hub demo cancelling messages after on…

### DIFF
--- a/demo/src/sandboxes/notification-hub/src/App.tsx
+++ b/demo/src/sandboxes/notification-hub/src/App.tsx
@@ -48,7 +48,7 @@ function MessageHub({
         })
       )
     },
-    config: (item, index, phase) => key => (phase === 'enter' && key === 'life' ? { duration: timeout } : config),
+    config: (item, index, phase) => key => phase === 'enter' && key === 'life' ? { duration: timeout } : config,
   })
 
   useEffect(() => {
@@ -67,7 +67,7 @@ function MessageHub({
             <Button
               onClick={(e: MouseEvent) => {
                 e.stopPropagation()
-                if (cancelMap.has(item)) cancelMap.get(item)()
+                if (cancelMap.has(item) && life.get() !== '0%') cancelMap.get(item)()
               }}>
               <X size={18} />
             </Button>


### PR DESCRIPTION
Fix #1642

### Why

The Notification Hub useTransition example persists notifications when clicking to "cancel" after onRest. In this scenario, the "cancel" function cancels the leave animation.

### What

Ensure that "cancel" is not called during the leave animation by checking the value of the life prop when clicking the "x" button


### Checklist

- [ ] Documentation updated
- [ ] Demo added
- [x] Ready to be merged
