### PR TITLE
Fix iteration across arrays to avoid conflict with polyfilled Array variants

### DIFF
--- a/packages/shared/src/helpers.ts
+++ b/packages/shared/src/helpers.ts
@@ -53,6 +53,12 @@ export function eachProp<T extends object, This>(
   ) => void,
   ctx?: This
 ) {
+  if (is.arr(obj)) {
+    for (let i = 0; i < obj.length; i++) {
+      fn.call(ctx as any, obj[i] as any, `${i}`)
+    }
+    return;
+  }
   for (const key in obj) {
     if (obj.hasOwnProperty(key)) {
       fn.call(ctx as any, obj[key] as any, key)


### PR DESCRIPTION
### Why
Resolves https://github.com/pmndrs/react-spring/issues/1649: using for-in to traverse Arrays is normally safe, but with Ember's observability polyfills, it causes `createHost` to break on primitive iteration.

### What

This fix swaps iteration to use a for loop when the traversed object is an array.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [X] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
