### PR TITLE
fix: handle ParallaxLayers inside fragments (#1667)

### DIFF
--- a/packages/parallax/src/index.tsx
+++ b/packages/parallax/src/index.tsx
@@ -14,6 +14,13 @@ function getScrollType(horizontal: boolean) {
   return horizontal ? 'scrollLeft' : 'scrollTop'
 }
 
+function isReactFragment(node: any) {
+  if (node.type) {
+    return node.type === React.Fragment
+  }
+  return node === React.Fragment
+}
+
 const START_TRANSLATE_3D = 'translate3d(0px,0px,0px)'
 const START_TRANSLATE = 'translate(0px,0px)'
 
@@ -339,17 +346,27 @@ export const Parallax = React.memo(
                 ...props.innerStyle,
               }}>
               <ParentContext.Provider value={state}>
-                {React.Children.map(
-                  children,
-                  (child: any) => !child.props.sticky && child
-                )}
+                {React.Children.map(children, (child: any) => {
+                  if (isReactFragment(child)) {
+                    return React.Children.map(
+                      child.props.children,
+                      child => !child.props.sticky && child
+                    )
+                  }
+                  return !child.props.sticky && child
+                })}
               </ParentContext.Provider>
             </a.div>
             <ParentContext.Provider value={state}>
-              {React.Children.map(
-                children,
-                (child: any) => child.props.sticky && child
-              )}
+              {React.Children.map(children, (child: any) => {
+                if (isReactFragment(child)) {
+                  return React.Children.map(
+                    child.props.children,
+                    child => child.props.sticky && child
+                  )
+                }
+                return child.props.sticky && child
+              })}
             </ParentContext.Provider>
           </>
         )}


### PR DESCRIPTION
### Why

Resolves #1667 

### What

I've added a check where `children` is mapped to see if the `child` is a `React.Fragment`. If it is, we also map over the `fragment`'s `children`. 

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Ready to be merged

A couple related questions/thoughts:

* I threw together a very simple `isReactFragment` function just to confirm this works. Should we use the `react-is` package instead? One benefit of that is that it might also aid in figuring out a solution to #1639 (if we decide that we should do something about that). Also, it will be less brittle because we won't be relying on React internals.
* I'm not sure if the way in which I map over the `children` of a `fragment` is ideal.

Hopefully, one day, `overflow: clip` will solve most of the workarounds we use for `sticky`.
