### PR TITLE
fix(native): add children prop

### DIFF
--- a/targets/native/src/animated.ts
+++ b/targets/native/src/animated.ts
@@ -1,4 +1,4 @@
-import { ForwardRefExoticComponent } from 'react'
+import { ForwardRefExoticComponent, ReactNode } from 'react'
 import { ViewStyle, RecursiveArray } from 'react-native'
 import {
   AssignableKeys,
@@ -19,9 +19,10 @@ export type WithAnimated = {
 } & AnimatedPrimitives
 
 /** The type of an `animated()` component */
-export type AnimatedComponent<
-  T extends ElementType
-> = ForwardRefExoticComponent<AnimatedProps<ComponentPropsWithRef<T>>>
+export type AnimatedComponent<T extends ElementType> =
+  ForwardRefExoticComponent<
+    AnimatedProps<ComponentPropsWithRef<T>> & { children: ReactNode }
+  >
 
 /** The props of an `animated()` component */
 export type AnimatedProps<Props extends object> = {


### PR DESCRIPTION
### Why

As reported in #1572, react-spring does not accept props derived directly from React, like props.children.

### What

This PR adds the children prop to AnimatedComponent's types.

### Checklist

- [ ] Documentation updated
- [ ] Demo added
- [x] Ready to be merged
