### PR TITLE
docs: Describe combining ref forwarding with `animated`

### DIFF
--- a/docs/src/pages/basics.mdx
+++ b/docs/src/pages/basics.mdx
@@ -380,3 +380,48 @@ useEffect(() => {
   api.start({ x: 100, y: 100 })
 }, [])
 ```
+
+### Forwarding refs and the `animated` HoC
+
+For performance reasons, the attributes of animated DOM elements are updated directly by `animated` using a ref to the DOM node, rather than via React updates. Internally, `animated` figures out the difference between DOM elements and regular components by checking the type of the component using a `ref`. This means that if you use `forwardRef` on a component wrapped with `animated` and then pass that ref onto a DOM node, `animated` will treat that component as though it were a DOM node itself, and will stop triggering React updates to interpolate when the animated props change.
+
+For example:
+
+```jsx
+const MyAnimatedComponent = animated(({ value }) => (
+  <div>{value}</div>
+))
+
+const MyAnimatedComponentWithRefForwarding = animated(forwardRef(({ value }, ref) => (
+  <div ref={ref}>{value}</div>
+)))
+
+const MyComponentWithSpring = () => {
+  const { value } = useSpring({
+    from: { value: 0 },
+    to: { value: 1 },
+  });
+  
+  return (
+    <>
+      /* This component will automatically update as "value" changes */
+      <MyAnimatedComponent value={value} />
+      
+      /* This component will not automatically update as "value" changes */
+      <MyAnimatedComponentWithRefForwarding value={value} />
+    </>
+  );
+}
+```
+
+You can work around this problem by forwarding refs as regular props:
+
+```jsx
+const AnimatedComponent = animated(({ value, forwardedRef }) => (
+  <div ref={forwardedRef}>{value}</div>
+))
+
+const AnimatedComponentWithRefForwarding = useRef((props, ref) => (
+  <AnimatedComponent {...props} forwardedRef={ref} />
+))
+```


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Resolves #1639 by documenting an issue with combining `animated` with `forwardRef` and explaining how to work around it.

### What

I've updated the documentation to describe the problem in detail with examples and describe a workaround.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
