### PR TITLE
Docs fix

### DIFF
--- a/docs/src/pages/common/props.mdx
+++ b/docs/src/pages/common/props.mdx
@@ -241,7 +241,7 @@ So lets break this down:
 
 #### Events as objects
 
-Events like can also be defined on a per-key basis.
+Events like `onRest` can also be defined on a per-key basis.
 
 ```jsx
 useSpring({

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -98,7 +98,7 @@ You can also support this project by becoming a sponsor. Your logo will show up 
 <a href="https://aragon.org/">
   <img
     width="300"
-    src="https://wiki.aragon.org/design/logo/svg/imagetype.svg"
+    src="https://assets.website-files.com/602ced7da46f594dd6700e15/602cf7ea9fc1f41358f0ae27_5e99778310343ed2dfe89331_logo_big.svg"
   />
 </a>
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

A word appears to be missing from the [props.mdx](https://github.com/pmndrs/react-spring/blob/master/docs/src/pages/common/props.mdx) doc. It says: "Events like can also be defined on a per-key basis" above an example that uses `onRest` as the example event. We extrapolate from there that the sentence was intended to read "Events like `onRest` can also be defined on a per-key basis." 

Also the Gold sponsor image is broken [in the docs](https://react-spring.io/#gold-sponsors), as noted in [a PR](https://github.com/pmndrs/react-spring/pull/1748) addressing the same issue (but in the README.) This corrects the img src as per the work of that PR's author, [kabilanvennila](https://github.com/kabilanvennila). The image is significantly larger than other sponsor icons on the page, but I have assumed that that behavior was deliberate (and can correct if needed.)

### What
Steps to reproduce issues:

- Missing text:
1. Navigate to the [`Events as objects` portion of the props doc](https://react-spring.io/common/props#events-as-objects)
2. Note that the text directly below the `Events as objects` header reads: `Events like can also be defined on a per-key basis.`
3. Note that the example given in the markup below is the event `onRest`

_Before:_
![Screen Shot 2021-11-18 at 12 02 03 PM](https://user-images.githubusercontent.com/11150372/142488720-8b45762a-5ba8-4873-8016-ea866c972b9d.png)

_After:_
![Screen Shot 2021-11-18 at 12 00 05 PM](https://user-images.githubusercontent.com/11150372/142488735-2d62786a-b602-424f-9121-7a931516189b.png)

- Missing logo:
1. Navigate to the [Gold sponsors list in the docs](https://react-spring.io/#gold-sponsors)
2. Note that the link to the image is broken, as noted [here](https://github.com/pmndrs/react-spring/pull/1748#issuecomment-965643032), in the PR addressing this same issue in the README. 

_Before:_
![Screen Shot 2021-11-18 at 12 01 08 PM](https://user-images.githubusercontent.com/11150372/142488753-a6cb0369-ce54-4baf-ab75-a287abcb23d9.png)


_After:_
![Screen Shot 2021-11-18 at 12 00 31 PM](https://user-images.githubusercontent.com/11150372/142488763-a35b3103-768e-473d-a594-185b5c7e2844.png)


### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Demo added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
