### PR TITLE
fix: update overflow css property without mixing shorthand and non-shorthand properties

### DIFF
--- a/packages/parallax/src/index.tsx
+++ b/packages/parallax/src/index.tsx
@@ -321,7 +321,16 @@ export const Parallax = React.memo(
       return () => window.removeEventListener('resize', onResize, false)
     })
 
-    const overflow = enabled ? 'scroll' : 'hidden'
+    const overflow: React.CSSProperties = enabled
+      ? {
+          overflowY: horizontal ? 'hidden' : 'scroll',
+          overflowX: horizontal ? 'scroll' : 'hidden',
+        }
+      : {
+          overflowY: 'hidden',
+          overflowX: 'hidden',
+        }
+
     return (
       <a.div
         {...rest}
@@ -333,9 +342,7 @@ export const Parallax = React.memo(
           position: 'absolute',
           width: '100%',
           height: '100%',
-          overflow,
-          overflowY: horizontal ? 'hidden' : overflow,
-          overflowX: horizontal ? overflow : 'hidden',
+          ...overflow,
           WebkitOverflowScrolling: 'touch',
           WebkitTransform: START_TRANSLATE,
           msTransform: START_TRANSLATE,


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->
It fixes the following issue: https://github.com/pmndrs/react-spring/issues/1766

Also, you can check an example here:
https://codesandbox.io/s/react-spring-parallax-issue-1766-f4iow?file=/src/App.js

### What

<!-- what have you done, if its a bug, whats your solution? -->
I have changed the way the property `overflow` is provided to the Parallax component, instead of mixing the shorthand and the non-shorthand properties, I'm using only non-shorthand.

It will avoid this:
![image](https://user-images.githubusercontent.com/7729844/143090747-53579c3a-590f-466c-9f84-30e058b0d178.png)


### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Demo added
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
