### PR TITLE
Feature/add container refs

### DIFF
--- a/docs/src/pages/components/parallax.mdx
+++ b/docs/src/pages/components/parallax.mdx
@@ -52,16 +52,34 @@ import { Parallax, ParallaxLayer } from '@react-spring/parallax'
 | horizontal? | boolean       | Whether or not the container scrolls horizontally. Defaults to `false`.          |
 | innerStyle? | CSSProperties | CSS object to style the inner `Parallax` wrapper (not the scrollable container)  |
 
-### `scrollTo`
+### `ref` Properties
 
-`Parallax` also has a `scrollTo` function for click-to-scroll. It takes one paramater: the number of the page to scroll to
-(Pages are zero-indexed so `scrollTo(0)` will scroll to the first page, etc).
+`Parallax` also has a few useful properties that you can access using a `ref`:
+
+```jsx
+const ref = useRef()
+...
+<Parallax ref={ref}>
+```
+
+#### `ref.current.scrollTo`
+
+A function for click-to-scroll. It takes one paramater: the number of the page to scroll to. Pages are zero-indexed, so `scrollTo(0)` will scroll to the first page, `scrollTo(1)` to the second, etc.
+
+#### `ref.current.container`
+
+The `ref` for the outer container `div` of `Parallax`, for when you need access to the actual DOM Element.
+
+**NOTE**: since it is also a `ref`, it must be accessed with `ref.current.container.current`.
+
+#### `ref.current.content`
+
+The `ref` for the inner container `div` of `Parallax`.
 
 ### Usage Notes
 
 - All direct `children` of `Parallax` must be `ParallaxLayer`s (or `fragment`s whose only direct `children` are `ParallaxLayer`s).
-- `Parallax` is a scrollable container so all scroll events are fired from the container itself -- listening for scroll on `window` won't work.
-- `scrollTo` is a method on `Parallax` -- you access it with a `ref` and then `ref.current.scrollTo(pageNumber)`.
+- `Parallax` is a scrollable container so all scroll events are fired from the container itself -- listening for scroll on `window` won't work (but you _can_ use `ref.current.container`).
 
 ## ParallaxLayer
 

--- a/packages/parallax/README.md
+++ b/packages/parallax/README.md
@@ -41,15 +41,34 @@ const Example = () => {
 | horizontal? | boolean       | Whether or not the container scrolls horizontally. Defaults to `false`.                                 |
 | innerStyle? | CSSProperties | CSS object to style the inner `Parallax` wrapper (not the scrollable container)                         |
 
-### `scrollTo`
+### `ref` Properties
 
-`Parallax` also has a `scrollTo` function for click-to-scroll. It takes one paramater: the number of the page to scroll to
-(Pages are zero-indexed so `scrollTo(0)` will scroll to the first page, etc).
+`Parallax` also has a few useful properties that you can access using a `ref`:
+
+```jsx
+const ref = useRef()
+...
+<Parallax ref={ref}>
+```
+
+#### `ref.current.scrollTo`
+
+A function for click-to-scroll. It takes one paramater: the number of the page to scroll to. Pages are zero-indexed, so `scrollTo(0)` will scroll to the first page, `scrollTo(1)` to the second, etc.
+
+#### `ref.current.container`
+
+The `ref` for the outer container `div` of `Parallax`, for when you need access to the actual DOM Element.
+
+**NOTE**: since it is also a `ref`, it must be accessed with `ref.current.container.current`.
+
+#### `ref.current.content`
+
+The `ref` for the inner container `div` of `Parallax`.
 
 ### Usage Notes
 
-- `Parallax` is a scrollable container so all scroll events are fired from the container itself -- listening for scroll on `window` won't work.
-- `scrollTo` is a method on `Parallax` -- you access it with a `ref` and then `ref.current.scrollTo(pageNumber)`.
+- All direct `children` of `Parallax` must be `ParallaxLayer`s (or `fragment`s whose only direct `children` are `ParallaxLayer`s).
+- `Parallax` is a scrollable container so all scroll events are fired from the container itself -- listening for scroll on `window` won't work (but you _can_ use `ref.current.container`).
 
 ## ParallaxLayer
 

--- a/packages/parallax/src/index.tsx
+++ b/packages/parallax/src/index.tsx
@@ -52,6 +52,8 @@ export interface IParallax {
   current: number
   controller: Controller<{ scroll: number }>
   layers: Set<IParallaxLayer>
+  container: React.MutableRefObject<any>
+  content: React.MutableRefObject<any>
   scrollTo(offset: number): void
   update(): void
   stop(): void
@@ -226,6 +228,9 @@ export const Parallax = React.memo(
       ...rest
     } = props
 
+    const containerRef = useRef<any>()
+    const contentRef = useRef<any>()
+
     const state: IParallax = useMemoOne(
       () => ({
         config,
@@ -236,6 +241,8 @@ export const Parallax = React.memo(
         offset: 0,
         controller: new Controller({ scroll: 0 }),
         layers: new Set<IParallaxLayer>(),
+        container: containerRef,
+        content: contentRef,
         update: () => update(),
         scrollTo: offset => scrollTo(offset),
         stop: () => state.controller.stop(),
@@ -248,9 +255,6 @@ export const Parallax = React.memo(
     }, [config])
 
     React.useImperativeHandle(ref, () => state)
-
-    const containerRef = useRef<any>()
-    const contentRef = useRef<any>()
 
     const update = () => {
       const container = containerRef.current


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Resolves #1770.

### What

Added the DOM `ref`s for the outer and inner `div` containers -- `container` and `content` respectively (as they were named pre-`9.x.x`). Also, updated docs and `README` to reflect changes.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Ready to be merged

For the docs, I updated the organization a little bit and made a "`ref` Properties" section that includes these two `ref`s, as well as the `scrollTo` method. It just seemed to stand out a little bit more, as opposed to a list (although, I suppose it could also be a table 🤔 ). 
