### PR TITLE
chore(docs): fix typo (correspend -> correspond)

### DIFF
--- a/docs/src/pages/hooks/use-chain.mdx
+++ b/docs/src/pages/hooks/use-chain.mdx
@@ -32,7 +32,7 @@ return (
 )
 ```
 
-You can optionally define timeSteps and a timeFrame (which defaults to a second). timeSteps is just an array with offsets between 0-1 that correspend to beginning and the end of the timeFrame.
+You can optionally define timeSteps and a timeFrame (which defaults to a second). timeSteps is just an array with offsets between 0-1 that correspond to the beginning and end of the timeFrame.
 
 ```jsx
 // The spring will start right away: 0.0 * 1000ms = 0ms


### PR DESCRIPTION
### Why / what

This PR fixes a typo in the docs for the `useChain` hook here: https://react-spring.io/hooks/use-chain#overview –  `correspend` -> `correspond`:

![image](https://user-images.githubusercontent.com/21834/146063096-4c4b4a81-ad3e-4135-9811-8b28d7ed8c2e.png)

Along the way it slightly restructures the sentence by moving the definite article before the first of the two corresponding nouns.

### Checklist

- [x] Documentation updated
- [x] Ready to be merged