### PR TITLE
Fix missing commas in api object

### DIFF
--- a/docs/src/pages/common/imperatives-and-refs.mdx
+++ b/docs/src/pages/common/imperatives-and-refs.mdx
@@ -80,9 +80,9 @@ const api = {
     // Cancel some or all animations depending on the keys passed, no keys will cancel all.
     stop: (cancel, keys) => this,
     // pause specific spring keys of the spring function
-    pause: (keys) => this
+    pause: (keys) => this,
     // resume specific spring keys of the spring function
-    resume: (keys) => this
+    resume: (keys) => this,
 }
 ```
 


### PR DESCRIPTION
### Why

There are missing commas in the api object.

### What

There are now sufficient commas in the object.

### Checklist

- [x] Documentation updated
- [x] Ready to be merged
