### PR TITLE
refactor: fix link to repo dependents

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Pages contain their own [examples](https://react-spring.io/hooks/use-spring#demo
   <a href="https://aragon.org/"><img width="285" src="assets/projects/aragon.png"></a>
 </p>
 
-And [many others](https://github.com/react-spring/react-spring/network/dependents)...
+And [many others...](https://github.com/pmndrs/react-spring/network/dependents)
 
 ## Backers
 

--- a/docs/src/pages/index.mdx
+++ b/docs/src/pages/index.mdx
@@ -85,7 +85,7 @@ Springs change that, animation becomes easy and approachable, everything you do 
 <GridUsedBy />
 <br />
 
-And [many others](https://github.com/drcmda/pmndrs/network/dependents) ...
+And [many others...](https://github.com/pmndrs/react-spring/network/dependents)
 
 ## Funding
 

--- a/packages/react-spring/README.md
+++ b/packages/react-spring/README.md
@@ -50,7 +50,7 @@ Springs change that, animation becomes easy and approachable, everything you do 
   <a href="https://aragon.org/"><img width="285" src="assets/projects/aragon.png"></a>
 </p>
 
-And [many others](https://github.com/react-spring/react-spring/network/dependents) ...
+And [many others...](https://github.com/pmndrs/react-spring/network/dependents)
 
 ## Funding
 


### PR DESCRIPTION
Minor link change + updated style to include ellipsis inside the link.

Before:
<img width="154" alt="Screenshot 2022-03-10 at 15 55 43" src="https://user-images.githubusercontent.com/448410/157688642-e7659cdf-b368-456c-aa75-b054703f2079.png">

After:
<img width="160" alt="Screenshot 2022-03-10 at 15 55 24" src="https://user-images.githubusercontent.com/448410/157688672-f0c80e17-84d9-4728-b651-8e3ddac11157.png">

