### PR TITLE
Add explicit semicolon to prevent syntax error in TypeScript 4.7

### DIFF
--- a/packages/types/interpolation.d.ts
+++ b/packages/types/interpolation.d.ts
@@ -6,7 +6,7 @@ export type EasingFunction = (t: number) => number
 export type ExtrapolateType = 'identity' | 'clamp' | 'extend'
 
 export interface InterpolatorFactory {
-  <In, Out>(interpolator: InterpolatorFn<In, Out>): typeof interpolator
+  <In, Out>(interpolator: InterpolatorFn<In, Out>): typeof interpolator;
 
   <Out>(config: InterpolatorConfig<Out>): (input: number) => Animatable<Out>
 


### PR DESCRIPTION
### Why

Without an explicit semicolon the TS parser treats the input as the new syntax, `typeof interpolator<Out>`
https://github.com/microsoft/TypeScript/issues/48711

### What

Add an explicit semicolon. I'm assuming that there is no auto-formatting step that will strip it away.

### Checklist

- [x] Ready to be merged