### PR TITLE
[do not merge] Throw in StrictMode-only block to demonstrate execution

### DIFF
--- a/packages/core/src/hooks/useTransition.tsx
+++ b/packages/core/src/hooks/useTransition.tsx
@@ -112,11 +112,15 @@ export function useTransition(
      * because usedTransitions on mount is typically null.
      */
     each(usedTransitions.current!, t => {
-      t.ctrl.ref?.add(t.ctrl)
-      const change = changes.get(t)
-      if (change) {
-        t.ctrl.start(change.payload)
-      }
+      // The above comment claims that this code will not execute outside
+      // of StrictMode. If that were true, throwing here wouldn't break any
+      // of the useTransition tests, since StrictMode is not enabled in tests.
+      throw new Error('Unexpected invocation.')
+      // t.ctrl.ref?.add(t.ctrl)
+      // const change = changes.get(t)
+      // if (change) {
+      //   t.ctrl.start(change.payload)
+      // }
     })
 
     // Destroy all transitions on dismount.


### PR DESCRIPTION
### Why

Not for merge.

This PR demonstrates the issue in https://github.com/pmndrs/react-spring/issues/1890. It shows that this code block is executed outside of `StrictMode`, contradicting the comment immediately above it. Submitting as a PR so that CI can confirm the test failures.

### What

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Demo added
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
