### PR TITLE
fix: make children on AnimatedComponent optional

### DIFF
--- a/targets/native/src/animated.ts
+++ b/targets/native/src/animated.ts
@@ -21,7 +21,7 @@ export type WithAnimated = {
 /** The type of an `animated()` component */
 export type AnimatedComponent<T extends ElementType> =
   ForwardRefExoticComponent<
-    AnimatedProps<ComponentPropsWithRef<T>> & { children: ReactNode }
+    AnimatedProps<ComponentPropsWithRef<T>> & { children?: ReactNode }
   >
 
 /** The props of an `animated()` component */


### PR DESCRIPTION
### Why

It fixes the issue described here: https://github.com/pmndrs/react-spring/pull/1705/files#r913068712

### What

I have made the `children` property optional on the `AnimatedComponent` component.

I tested this out in my project by editing the file in `node_modules`, making the same change as proposed here.

### Checklist

- [x] Ready to be merged
