### PR TITLE
fix: run stop function and don't flush the current queue

### DIFF
--- a/packages/rafz/src/index.test.ts
+++ b/packages/rafz/src/index.test.ts
@@ -25,6 +25,7 @@ describe('raf looping', () => {
   })
   it('stops looping after single job', () => {
     raf(() => {})
+    mockRaf.step()
     expect(__raf.isRunning()).toBe(true)
     mockRaf.step()
     expect(__raf.isRunning()).toBe(false)
@@ -35,6 +36,7 @@ describe('raf looping', () => {
     mockRaf.step()
     expect(fn).toHaveBeenCalledTimes(1)
     raf(fn)
+    mockRaf.step()
     expect(__raf.isRunning()).toBe(true)
     mockRaf.step()
     expect(__raf.isRunning()).toBe(false)

--- a/packages/rafz/src/index.ts
+++ b/packages/rafz/src/index.ts
@@ -53,9 +53,9 @@ let findTimeout = (time: number) =>
 raf.cancel = fn => {
   onStartQueue.delete(fn)
   onFrameQueue.delete(fn)
+  onFinishQueue.delete(fn)
   updateQueue.delete(fn)
   writeQueue.delete(fn)
-  onFinishQueue.delete(fn)
 }
 
 raf.sync = fn => {
@@ -157,15 +157,17 @@ function update() {
     pendingCount -= count
   }
 
+  if (!pendingCount) {
+    stop()
+
+    return
+  }
+
   onStartQueue.flush()
   updateQueue.flush(prevTs ? Math.min(64, ts - prevTs) : 16.667)
   onFrameQueue.flush()
   writeQueue.flush()
   onFinishQueue.flush()
-
-  if (!pendingCount) {
-    stop()
-  }
 }
 
 interface Queue<T extends Function = any> {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

- resolves #1844 

### What

<!-- what have you done, if its a bug, whats your solution? -->

- calls stop before flushing the queue to avoid loops speeding up

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
