### PR TITLE
fix: useTransition would not obey refs

### DIFF
--- a/.changeset/gentle-students-wonder.md
+++ b/.changeset/gentle-students-wonder.md
@@ -1,0 +1,16 @@
+---
+'@react-spring/core': patch
+'@react-spring/animated': patch
+'@react-spring/parallax': patch
+'@react-spring/rafz': patch
+'react-spring': patch
+'@react-spring/shared': patch
+'@react-spring/types': patch
+'@react-spring/konva': patch
+'@react-spring/native': patch
+'@react-spring/three': patch
+'@react-spring/web': patch
+'@react-spring/zdog': patch
+---
+
+fix: react18 useTransition on mount

--- a/packages/core/src/hooks/useTransition.tsx
+++ b/packages/core/src/hooks/useTransition.tsx
@@ -104,19 +104,15 @@ export function useTransition(
 
   useOnce(() => {
     /**
-     * This _should_ only run in `StrictMode` where everything
-     * is destroyed and remounted, because the enter animation
-     * was most likely cancelled we run it again on initial mount.
+     * If transitions exist on mount of the component
+     * then reattach their refs on-mount, this was required
+     * for react18 strict mode to work properly.
      *
-     * This does nothing when `StrictMode` isn't enabled,
-     * because usedTransitions on mount is typically null.
+     * See https://github.com/pmndrs/react-spring/issues/1890
      */
-    each(usedTransitions.current!, t => {
-      t.ctrl.ref?.add(t.ctrl)
-      const change = changes.get(t)
-      if (change) {
-        t.ctrl.start(change.payload)
-      }
+    each(transitions, t => {
+      ref?.add(t.ctrl)
+      t.ctrl.ref = ref
     })
 
     // Destroy all transitions on dismount.
@@ -159,6 +155,7 @@ export function useTransition(
         if (~i) transitions[i] = t
       }
     })
+
   // Mount new items with fresh transitions.
   each(items, (item, i) => {
     if (!transitions[i]) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

- resolves #1890 

When attaching refs to `useTransition` the animations were automatically starting regardless of the fact they shouldn't be.
This meant animations were freely running when they shouldnt be.

This problem could be the cause of #1933

### What

<!-- what have you done, if its a bug, whats your solution? -->

- Adds test to ensure animation does not start when a ref is attached
- reattaches refs to controllers when transitions are apparent when the component is mounted

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Demo added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
