### PR TITLE
docs: added examples for interpolation function 'to'

### DIFF
--- a/docs/src/pages/common/interpolation.mdx
+++ b/docs/src/pages/common/interpolation.mdx
@@ -13,6 +13,70 @@
 | output           | undefined | Array of mapped output ranges                    |
 | map              | undefined | Value filter applied to input value              |
 
+## Example 
+
 A range shortcut: `value.to([...inputRange], [...outputRange])`
 
 Or a function: `value.to(v => ...)`
+
+## Alternate method using `to` function
+#### For single variables
+
+Example is using `to` for interpolating `y` style for a `transform: translate3d(x,y,z)` animation
+
+```
+import { useTransition, to } from "react-spring";
+
+const transitions = useTransition(
+    elements.map((element, index) => ({
+      ...element,
+      y: ...logic,
+      x: ...logic
+    })),
+    {
+      ...settings
+    }
+  );
+
+  return (
+      {transitions((styles, item, { key }) => (
+        <a.div
+          key={key}
+          className="card"
+          style={{
+            transform: to(
+              styles.y,
+              (y) => `translate3d(0,${y}px,0)`
+            ),
+          }}....
+```
+
+#### For multiple variables
+
+Example is using `to` for interpolating `x` and `y` styles
+
+
+```
+import { useTransition, to } from "react-spring";
+  const transitions = useTransition(
+    elements.map((element, index) => ({
+      ...element,
+      y: ...logic,
+      x: ...logic
+    })),
+    {
+      ...settings
+    }
+  );
+  return (
+      {transitions((styles, item, { key }) => (
+          <a.div
+          key={key}
+          className="card"
+          style={{
+              transform: to(
+                  [styles.x, styles.y],
+              (x, y) => `translate3d(${x}px,${y}px,0)`
+            ),
+          }}....
+```


### PR DESCRIPTION
### Why

The docs for [interpolation](https://react-spring.dev/common/interpolation#interpolations) are missing the `to` function implementation. I had to go through some examples to figure out how to use the `to` function. My addition to the docs should help other people who are facing a similar issue.

### What

Have added an example of an implementation of `to` which helps explain it's use case with `useTransition` as well.  Please let me know if any changes are required in the formatting.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [ ] Demo added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
