### PR TITLE
fix(docs): remove typo

### DIFF
--- a/docs/app/routes/docs/components/use-transition.mdx
+++ b/docs/app/routes/docs/components/use-transition.mdx
@@ -20,7 +20,7 @@ want to be left in the DOM, e.g. a dialog.
 
 `useTransition` depends on an `array` of data. That data can be anything you want, we
 use a lot of internals to track each datum including inferring the keys, this is the
-first argument. The second is a you're config object, this is different to
+first argument. The second is a config object, which is different to
 [`useSpring`](/docs/components/use-spring) or [`useSprings`](/docs/components/use-springs) so take note!
 
 ### With a function & deps


### PR DESCRIPTION
### Why

There was a typo in the docs.

### What

Rephrased the sentence.

### Checklist

- [x] Documentation updated
- [x] Ready to be merged