### PR TITLE
docs(fix): typo

### DIFF
--- a/docs/app/components/HomeBlocks/HomeBlockImperative.tsx
+++ b/docs/app/components/HomeBlocks/HomeBlockImperative.tsx
@@ -51,7 +51,7 @@ export const HomeBlockImperative = () => (
       }}>
       <p>
         Use our imperative API methods to run animations without updating state.
-        Repsond to events without the react rendering overhead to achieve
+        Respond to events without the react rendering overhead to achieve
         smooth, fluid animation.
       </p>
     </HomeBlockCopy>


### PR DESCRIPTION
### Why

Typo in docs

### What

Change "Repsond" to "Respond"

### Checklist

- [x] Documentation updated
- [ ] Demo added
- [x] Ready to be merged