### PR TITLE
docs: fix a typo in `useResize` docs (obsere → observe)

### DIFF
--- a/docs/app/routes/docs/utilities/use-resize.mdx
+++ b/docs/app/routes/docs/utilities/use-resize.mdx
@@ -16,7 +16,7 @@ isNew: true
 
 A small abstraction around the [`useSpring`](/docs/components/use-spring) hook. It returns a `SpringValues`
 object with the `width` and `height` of the element it's attached to & doesn't necessarily have to be attached
-to the window, by passing a `container` you can obsere that element's size instead.
+to the window, by passing a `container` you can observe that element's size instead.
 
 ## Usage
 

--- a/packages/core/src/hooks/useResize.ts
+++ b/packages/core/src/hooks/useResize.ts
@@ -13,7 +13,7 @@ export interface UseResizeOptions extends Omit<SpringProps, 'to' | 'from'> {
  * A small abstraction around the `useSpring` hook. It returns a `SpringValues` 
  * object with the `width` and `height` of the element it's attached to & doesn't 
  * necessarily have to be attached to the window, by passing a `container` you 
- * can obsere that element's size instead.
+ * can observe that element's size instead.
  * 
  ```jsx
     import { useResize, animated } from '@react-spring/web'


### PR DESCRIPTION
### What

Fixes a small typo in `useResize` docs.

### Checklist

- [x] Ready to be merged
