### PR TITLE
docs: fix typo in `useResize` Docs (wrong function name)

### DIFF
--- a/docs/app/routes/docs/utilities/use-resize.mdx
+++ b/docs/app/routes/docs/utilities/use-resize.mdx
@@ -40,7 +40,7 @@ import { USE_SCROLL_CONFIG_DATA } from '~/data/fixtures'
 ## Typescript
 
 ```tsx
-function useScroll(configuration: ConfigObject): SpringValues
+function useResize(configuration: ConfigObject): SpringValues
 ```
 
 Where `ConfigObject` is described [above](#reference)


### PR DESCRIPTION
fix Typescript section of useResize documentation

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Wrong function name in documentation

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

Just changed function name in documentation

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [ ] Demo added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->

It is just a fix for useResize documentation.