### PR TITLE
docs(fix): cannot animate between AnimatedString and AnimatedValue, as the "to" prop suggests

### DIFF
--- a/docs/app/routes/docs/concepts/animated-elements.mdx
+++ b/docs/app/routes/docs/concepts/animated-elements.mdx
@@ -82,7 +82,7 @@ const App = () => {
     },
     to: {
       opacity: 1,
-      y: 0,
+      y: '0',
     },
   })
 


### PR DESCRIPTION
### Why
I ran to this error today while I was reading the [animated components section](https://www.react-spring.dev/docs/concepts/animated-elements#animating-components).  The example I was trying to implement is the one attached in the code below.
I'm using Next.js and the error has been resolved once I updated the type of `to.y`: `string`, instead of  `to.y`: `number`.  

<div  align="left" dir="auto">
  <img src ="https://user-images.githubusercontent.com/56412800/213560449-179f3830-9d0c-4940-8459-eed70b1b69af.png" alt="animated-elements" height=480 width=430  />
    <img src ="https://user-images.githubusercontent.com/56412800/213560754-20b15868-d8a6-4b0e-885e-2f537289a979.png" alt="animated-elements" height=480 width=372 />  
</div>

### What
- Change the type of `to.y` coordinate to match the one used in `from.y`; which is happen to be a string in this example.

### Checklist
 - [x] Documentation updated
 - [ ] Demo added
 - [x] Ready to be merged