### PR TITLE
feat: enable SpringRef.set to be called with a function

### DIFF
--- a/.changeset/strange-falcons-confess.md
+++ b/.changeset/strange-falcons-confess.md
@@ -1,0 +1,16 @@
+---
+'@react-spring/core': minor
+'@react-spring/animated': minor
+'@react-spring/parallax': minor
+'@react-spring/rafz': minor
+'react-spring': minor
+'@react-spring/shared': minor
+'@react-spring/types': minor
+'@react-spring/konva': minor
+'@react-spring/native': minor
+'@react-spring/three': minor
+'@react-spring/web': minor
+'@react-spring/zdog': minor
+---
+
+feat: add function to SpringRef.set

--- a/docs/app/routes/docs/advanced/spring-ref.mdx
+++ b/docs/app/routes/docs/advanced/spring-ref.mdx
@@ -110,10 +110,12 @@ resume(keys?: OneOrMore<string>): this
 
 ### Set
 
-Update the state of each controller without animating.
+Update the state of each controller without animating. Accepts either a partial state object or a
+function that returns a partial state object.
 
 ```ts
 set(values: Partial<State>): void
+set(values: (index: number, ctrl: Controller<State>) => Partial<State>): void
 ```
 
 ### Start


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

* resolves #1725

### What

<!-- what have you done, if its a bug, whats your solution? -->

* SpringRef.set now accepts a function meaning you can `set` different Controllers

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
