### PR TITLE
fix: allow container ref with null and undefined for useResize

### DIFF
--- a/docs/app/data/fixtures.tsx
+++ b/docs/app/data/fixtures.tsx
@@ -473,6 +473,14 @@ export const USE_SCROLL_CONFIG_DATA: CellData[][] = [
   ),
 ]
 
+export const USE_RESIZE_CONFIG_DATA: CellData[][] = [
+  ['container', 'React.MutableRefObject<HTMLElement | null | undefined>', null],
+  ...DEFAULT_CONFIG_DATA.filter(
+    row =>
+      row[0] !== 'from' && typeof row[0] === 'object' && row[0]?.label !== 'to'
+  ),
+]
+
 export const USESPRINGVALUE_CONFIG_DATA: CellData[][] = [
   [
     {

--- a/docs/app/routes/docs/utilities/use-resize.mdx
+++ b/docs/app/routes/docs/utilities/use-resize.mdx
@@ -33,9 +33,9 @@ function MyComponent() {
 ## Reference
 
 import { TablesConfiguration } from '~/components/Tables/TablesConfig'
-import { USE_SCROLL_CONFIG_DATA } from '~/data/fixtures'
+import { USE_RESIZE_CONFIG_DATA } from '~/data/fixtures'
 
-<TablesConfiguration data={USE_SCROLL_CONFIG_DATA} />
+<TablesConfiguration data={USE_RESIZE_CONFIG_DATA} />
 
 ## Typescript
 

--- a/packages/core/src/hooks/useResize.ts
+++ b/packages/core/src/hooks/useResize.ts
@@ -6,7 +6,7 @@ import { SpringProps, SpringValues } from '../types'
 import { useSpring } from './useSpring'
 
 export interface UseResizeOptions extends Omit<SpringProps, 'to' | 'from'> {
-  container?: MutableRefObject<HTMLElement>
+  container?: MutableRefObject<HTMLElement | null | undefined>
 }
 
 /**


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Allow to pass nullish container references to `useResize`.

### What

Extended type of `useResize` to allow `null` and `undefined` as reference value types as well.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [ ] Demo added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
