### PR TITLE
fix: Export missing type `AnimationConfig`

### DIFF
--- a/.changeset/cool-brooms-boil.md
+++ b/.changeset/cool-brooms-boil.md
@@ -1,0 +1,5 @@
+---
+'@react-spring/core': patch
+---
+
+Export missing type AnimationConfig

--- a/packages/core/src/types/objects.ts
+++ b/packages/core/src/types/objects.ts
@@ -4,6 +4,8 @@ import type { AnimationConfig } from '../AnimationConfig'
 import type { SpringValue } from '../SpringValue'
 import type { Readable } from './internal'
 
+export type { AnimationConfig }
+
 /** The object type of the `config` prop. */
 export type SpringConfig = Partial<AnimationConfig>
 


### PR DESCRIPTION
Some open-source and largely used libraries such as nivo directly bind to the types being declared by `@react-pring/core` in some of their code.

For instance in nivo, the following code:

```ts
import { SpringValues } from '@react-spring/web'

//...
export interface NodeProps<Datum extends object> {
    //...
    animatedProps: SpringValues<NodeAnimatedProps>
    //...
}
```

Implicitely force nivo to be able to reference parts of the typings of `@react-spring/core` into their d.ts files if they want to be able to publish their package. It basiaclly results into `Partial<import("@react-spring/core").AnimationConfig>` in the produced d.ts at some point. And as a consequence TypeScript complains with the error `error TS4023: Exported variable 'htmlDefaultProps' has or is using name 'AnimationConfig' from external module "/tmp/9a4cf066/node_modules/@react-spring/core/dist/index" but cannot be named.`.

The proposed change exposes `AnimationConfig` as a type, meaning we still don't expose the class, just its type. It would help into making nivo able to support recent version of `@react-spring/*`. See related issue on nivo's side: https://github.com/plouc/nivo/pull/2280

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Demo added
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
