### PR TITLE
docs: spelling fixes

### DIFF
--- a/docs/app/routes/docs/concepts/targets.mdx
+++ b/docs/app/routes/docs/concepts/targets.mdx
@@ -16,9 +16,9 @@ sidebar_position: 4
 ## What is a target?
 
 When a target is discussed it is sometimes in reference to the platform, e.g. you create a client side react application
-changes are it's targetted at the browser. However, if you write a server-side application then you're targetting node.
+chances are it's targetted at the browser. However, if you write a server-side application then you're targetting node.
 Whilst `react-spring` does support the targets `web` and `native` and _can_ be server-side rendered. This is not the type
-of target we're referring too.
+of target we're referring to.
 
 A target in `react-spring` is a `react reconciler` a.k.a `react renderer`. That is, a custom renderer that can process different
 JSX components, it's duty is to create / update and remove these elements from the browser. `react-dom` is a prime example of


### PR DESCRIPTION
correct spelling of 
"changes -> ""chances" 
"too" -> "to"

### Why

There were some spelling errors in the documentation.

### What

Corrected the spelling errors to what I thought was the correct grammar.

### Checklist

Changes:
- [x] Documentation updated
- [x] Ready to be merged


This is my first open source pr :)