### PR TITLE
docs: add css overscroll behavior and change max height of scroll area

### DIFF
--- a/docs/app/components/Menu/MenuDocs.tsx
+++ b/docs/app/components/Menu/MenuDocs.tsx
@@ -141,9 +141,10 @@ const DocsList = styled('ul', {
 
 const ScrollArea = styled('div', {
   '@tabletUp': {
-    maxHeight: '100%',
+    maxHeight: 'calc(90vh - 89px)',
     overflowY: 'scroll',
     pb: '$60',
+    overscrollBehaviorBlock: 'contain',
   },
 })
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

resolves #2135 

### What

Add CSS rule to ScrollArea: overscrollBehaviorBlock: 'contain'

Change max height of ScrollArea to: maxHeight: 'calc(90vh - 89px)' 
-89px is to account for header height

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
