### PR TITLE
doc: Fixed incorrect usage of "resume" instead of "reset"

### DIFF
--- a/docs/app/routes/docs/advanced/spring-value.mdx
+++ b/docs/app/routes/docs/advanced/spring-value.mdx
@@ -88,7 +88,7 @@ pause(): void;
 Restart the animation.
 
 ```ts
-resume(): void;
+reset(): void;
 ```
 
 ### Resume


### PR DESCRIPTION
### Why

Incorrect usage of "resume" in the [documentation](https://react-spring.dev/docs/advanced/spring-value#reset)

### What

Fixed incorrect usage of "resume" instead of "reset"

### Checklist

- [x] Documentation updated
- [x] Ready to be merged
