### PR TITLE
fix: add annotations for tree shaking

### DIFF
--- a/packages/core/src/hooks/useInView.native.ts
+++ b/packages/core/src/hooks/useInView.native.ts
@@ -1,6 +1,6 @@
 import { once, prefix } from '@react-spring/shared'
 
-const warnImplementation = once(console.warn)
+const warnImplementation = /* @__PURE__ */ once(console.warn)
 
 export const useInView = () => {
   warnImplementation(

--- a/packages/core/src/hooks/useResize.native.ts
+++ b/packages/core/src/hooks/useResize.native.ts
@@ -1,6 +1,6 @@
 import { once, prefix } from '@react-spring/shared'
 
-const warnImplementation = once(console.warn)
+const warnImplementation = /* @__PURE__ */ once(console.warn)
 
 export const useResize = () => {
   warnImplementation(

--- a/packages/core/src/hooks/useScroll.native.ts
+++ b/packages/core/src/hooks/useScroll.native.ts
@@ -1,6 +1,6 @@
 import { once, prefix } from '@react-spring/shared'
 
-const warnImplementation = once(console.warn)
+const warnImplementation = /* @__PURE__ */ once(console.warn)
 
 export const useScroll = () => {
   warnImplementation(

--- a/packages/parallax/src/index.tsx
+++ b/packages/parallax/src/index.tsx
@@ -8,7 +8,7 @@ import {
   config as configs,
 } from '@react-spring/web'
 
-const ParentContext = React.createContext<any>(null)
+const ParentContext = /* @__PURE__ */ React.createContext<any>(null)
 
 function getScrollType(horizontal: boolean) {
   return horizontal ? 'scrollLeft' : 'scrollTop'
@@ -75,8 +75,8 @@ export interface ParallaxLayerProps extends ViewProps {
   sticky?: StickyConfig
 }
 
-export const ParallaxLayer = React.memo(
-  React.forwardRef<IParallaxLayer, ParallaxLayerProps>(
+export const ParallaxLayer = /* @__PURE__ */ React.memo(
+  /* @__PURE__ */ React.forwardRef<IParallaxLayer, ParallaxLayerProps>(
     (
       { horizontal, factor = 1, offset = 0, speed = 0, sticky, ...rest },
       ref
@@ -216,8 +216,8 @@ export interface ParallaxProps extends ViewProps {
   children: React.ReactNode
 }
 
-export const Parallax = React.memo(
-  React.forwardRef<IParallax, ParallaxProps>((props, ref) => {
+export const Parallax = /* @__PURE__ */ React.memo(
+  /* @__PURE__ */ React.forwardRef<IParallax, ParallaxProps>((props, ref) => {
     const [ready, setReady] = useState(false)
     const {
       pages,

--- a/packages/rafz/src/index.ts
+++ b/packages/rafz/src/index.ts
@@ -9,7 +9,7 @@ import type {
 
 export type { FrameFn, FrameUpdateFn, Timeout, Throttled, Rafz }
 
-let updateQueue = makeQueue<FrameUpdateFn>()
+let updateQueue = /* @__PURE__ */ makeQueue<FrameUpdateFn>()
 
 /**
  * Schedule an update for next frame.
@@ -17,16 +17,16 @@ let updateQueue = makeQueue<FrameUpdateFn>()
  */
 export const raf: Rafz = fn => schedule(fn, updateQueue)
 
-let writeQueue = makeQueue<FrameFn>()
+let writeQueue = /* @__PURE__ */ makeQueue<FrameFn>()
 raf.write = fn => schedule(fn, writeQueue)
 
-let onStartQueue = makeQueue<FrameFn>()
+let onStartQueue = /* @__PURE__ */ makeQueue<FrameFn>()
 raf.onStart = fn => schedule(fn, onStartQueue)
 
-let onFrameQueue = makeQueue<FrameFn>()
+let onFrameQueue = /* @__PURE__ */ makeQueue<FrameFn>()
 raf.onFrame = fn => schedule(fn, onFrameQueue)
 
-let onFinishQueue = makeQueue<FrameFn>()
+let onFinishQueue = /* @__PURE__ */ makeQueue<FrameFn>()
 raf.onFinish = fn => schedule(fn, onFinishQueue)
 
 let timeouts: Timeout[] = []

--- a/packages/shared/src/colorMatchers.ts
+++ b/packages/shared/src/colorMatchers.ts
@@ -6,11 +6,17 @@ function call(...parts: string[]) {
   return '\\(\\s*(' + parts.join(')\\s*,\\s*(') + ')\\s*\\)'
 }
 
-export const rgb = new RegExp('rgb' + call(NUMBER, NUMBER, NUMBER))
-export const rgba = new RegExp('rgba' + call(NUMBER, NUMBER, NUMBER, NUMBER))
-export const hsl = new RegExp('hsl' + call(NUMBER, PERCENTAGE, PERCENTAGE))
+export const rgb = new RegExp(
+  'rgb' + /* @__PURE__ */ call(NUMBER, NUMBER, NUMBER)
+)
+export const rgba = new RegExp(
+  'rgba' + /* @__PURE__ */ call(NUMBER, NUMBER, NUMBER, NUMBER)
+)
+export const hsl = new RegExp(
+  'hsl' + /* @__PURE__ */ call(NUMBER, PERCENTAGE, PERCENTAGE)
+)
 export const hsla = new RegExp(
-  'hsla' + call(NUMBER, PERCENTAGE, PERCENTAGE, NUMBER)
+  'hsla' + /* @__PURE__ */ call(NUMBER, PERCENTAGE, PERCENTAGE, NUMBER)
 )
 export const hex3 = /^#([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/
 export const hex4 =

--- a/packages/shared/src/deprecations.ts
+++ b/packages/shared/src/deprecations.ts
@@ -18,14 +18,14 @@ export const once = <TFunc extends (...args: any) => any>(fn: TFunc) => {
   }
 }
 
-const warnInterpolate = once(console.warn)
+const warnInterpolate = /* @__PURE__ */ once(console.warn)
 export function deprecateInterpolate() {
   warnInterpolate(
     `${prefix}The "interpolate" function is deprecated in v9 (use "to" instead)`
   )
 }
 
-const warnDirectCall = once(console.warn)
+const warnDirectCall = /* @__PURE__ */ once(console.warn)
 export function deprecateDirectCall() {
   warnDirectCall(
     `${prefix}Directly calling start instead of using the api object is deprecated in v9 (use ".start" instead), this will be removed in later 0.X.0 versions`


### PR DESCRIPTION
### Why

Implements #1158.

### What

Adds pure annotations to tree-shake top-level expressions. This can be done at build-time with an AST such as from Babel. Need to verify whether built-ins like `Symbol#for` and `Set`/`WeakMap` constructors are picked up as pure. Same with mutations in Rafz.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Demo added
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
