### PR TITLE
docs: fix typo in testing guidelines

### DIFF
--- a/docs/app/routes/docs/guides/testing.mdx
+++ b/docs/app/routes/docs/guides/testing.mdx
@@ -127,7 +127,7 @@ correctly made.
 ## Skipping Animations
 
 The solution to this problem is to skip animations when testing. This can be done by using the `Globals` object and calling the `assign`
-method setting `skipAnimations` to `true`. You can does this immediately in the `setup` file for your tests or if you want more granual
+method setting `skipAnimations` to `true`. You can do this immediately in the `setup` file for your tests or if you want more granual
 control then you could use the `beforeAll | beforeEach` hooks to set it.
 
 ```tsx lines=2,5-10


### PR DESCRIPTION
Hello :)

### Why

There is a little typo in the testing guidelines visible [here](https://www.react-spring.dev/docs/guides/testing#skipping-animations):

![image](https://github.com/pmndrs/react-spring/assets/17161484/ce9972a2-3d24-4bb1-9a68-ef0a03b967a0)

### Checklist

- [x] Documentation updated
- [x] Ready to be merged

