### PR TITLE
fix: save updates between renders in useSpring in Next.JS 13

### DIFF
--- a/packages/core/src/hooks/useSprings.ts
+++ b/packages/core/src/hooks/useSprings.ts
@@ -128,7 +128,7 @@ export function useSprings(
   )
 
   const ctrls = useRef([...state.ctrls])
-  const updatesRef = useRef([])
+  const updatesRef = useRef<any[]>([])
   const { current: updates } = updatesRef
 
   // Cache old controllers to dispose in the commit phase.
@@ -155,7 +155,7 @@ export function useSprings(
   /** Fill the `updates` array with declarative updates for the given index range. */
   function declareUpdates(startIndex: number, endIndex: number) {
     updates.splice(0, updates.length)
-    
+
     for (let i = startIndex; i < endIndex; i++) {
       const ctrl =
         ctrls.current[i] ||

--- a/packages/core/src/hooks/useSprings.ts
+++ b/packages/core/src/hooks/useSprings.ts
@@ -128,7 +128,8 @@ export function useSprings(
   )
 
   const ctrls = useRef([...state.ctrls])
-  const updates: any[] = []
+  const updatesRef = useRef([])
+  const { current: updates } = updatesRef
 
   // Cache old controllers to dispose in the commit phase.
   const prevLength = usePrev(length) || 0
@@ -153,6 +154,8 @@ export function useSprings(
 
   /** Fill the `updates` array with declarative updates for the given index range. */
   function declareUpdates(startIndex: number, endIndex: number) {
+    updates.splice(0, updates.length)
+    
     for (let i = startIndex; i < endIndex; i++) {
       const ctrl =
         ctrls.current[i] ||


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

It's a cheap fix, maybe should correctly configure Next.js
I found that something strange happens with the React life-cycle within useSprings in the Next.js 13. There is useIsomorphicLayoutEffect, that should run with [updates](https://github.com/pmndrs/react-spring/blob/bbfc8be61648122c3a3526e25534d10911c81db4/packages/core/src/hooks/useSprings.ts#L204) array, that consist of config, callback and other props. Updates is simple array variable (not react ref) and it rewrites on every render, but it calculates in useMemo on first render. So, I debugged on some examples on react-spring site and found that effect should be called with not empty updates array, but in Next.JS 13 effect calls with empty array

resolves: https://github.com/pmndrs/react-spring/issues/2146

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

I wrapped updates variable into react ref

<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Demo added
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
