### PR TITLE
Type Error in docs: /docs/concepts/imperative-api#comparison

### DIFF
--- a/docs/app/routes/docs/concepts/imperative-api.mdx
+++ b/docs/app/routes/docs/concepts/imperative-api.mdx
@@ -21,7 +21,7 @@ to the `SpringRef` to create a multi-controller animation, similar to that of th
 
 ## Comparison
 
-What we can see from the below comparions, is that using the `api` object either returned from your `useSpring` hook,
+What we can see from the below comparisons, is that using the `api` object either returned from your `useSpring` hook,
 or generated via `useSpringRef` and passed to the hook, means your components do not re-render when the animation runs.
 
 ```tsx live=true template=imperative


### PR DESCRIPTION
A small change in docs to make it more readable. 
Fixed spelling mistake comparions -> comparisons.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why
Fixed spelling mistake comparions -> comparisons.

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

<!-- what have you done, if its a bug, whats your solution? -->
I have fixed a spelling mistake comparions -> comparisons.
### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [ ] Demo added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
