### PR TITLE
docs: fix link

### DIFF
--- a/docs/app/routes/docs.components.use-spring.mdx
+++ b/docs/app/routes/docs.components.use-spring.mdx
@@ -17,7 +17,7 @@ export const meta = formatFrontmatterToRemixMeta(frontmatter)
 
 # useSpring
 
-Our flagship hook. Applicable to most use-cases. If you want to orchestrate many of these hooks, consider using [`useSprings`](/components/use-springs).
+Our flagship hook. Applicable to most use-cases. If you want to orchestrate many of these hooks, consider using [`useSprings`](/docs/components/use-springs).
 
 ## Usage
 


### PR DESCRIPTION
Just a typo in the docs

<img width="670" alt="Capture d’écran 2024-02-18 à 23 59 40" src="https://github.com/pmndrs/react-spring/assets/124937/9f3445bf-ed12-4987-a6ee-350594845532">
