### PR TITLE
docs: modified useScroll usage code

### DIFF
--- a/docs/app/routes/docs/utilities/use-resize.mdx
+++ b/docs/app/routes/docs/utilities/use-resize.mdx
@@ -21,12 +21,30 @@ to the window, by passing a `container` you can observe that element's size inst
 ## Usage
 
 ```tsx
+import { useRef } from 'react'
 import { useResize, animated } from '@react-spring/web'
 
 function MyComponent() {
-  const { width, height } = useResize()
+  const resizeRef = useRef(null)
 
-  return <animated.div style={{ width, height }}>Hello World</animated.div>
+  const { width, height } = useResize({
+    container: resizeRef,
+  })
+
+  return (
+    <div ref={resizeRef} style={{ width: '100%', height: '300px' }}>
+      <animated.div
+        style={{
+          width: width.to(w => `${w}px`),
+          height: height.to(h => `${h}px`),
+          background: 'rgba(27, 26, 34, 0.8)',
+          color: 'white',
+        }}
+      >
+        Hello World
+      </animated.div>
+    </div>
+  )
 }
 ```
 

--- a/packages/core/src/hooks/useResize.ts
+++ b/packages/core/src/hooks/useResize.ts
@@ -16,16 +16,30 @@ export interface UseResizeOptions extends Omit<SpringProps, 'to' | 'from'> {
  * can observe that element's size instead.
  * 
  ```jsx
+    import { useRef } from "react";
     import { useResize, animated } from '@react-spring/web'
 
     function MyComponent() {
-      const { width } = useResize()
+        const resizeRef = useRef(null);
 
-      return (
-        <animated.div style={{ width }}>
-          Hello World
-        </animated.div>
-      )
+        const { width, height } = useResize({
+          container: resizeRef,
+        });
+      
+        return (
+          <div ref={resizeRef} style={{ width: "100%", height: "300px" }}>
+            <animated.div
+              style={{
+                width: width.to((w) => `${w}px`),
+                height: height.to((h) => `${h}px`),
+                background: "rgba(27, 26, 34, 0.8)",
+                color: "white",
+              }}
+            >
+              Hello World
+            </animated.div>
+          </div>
+        );
     }
   ```
  * 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Upon attempting to use the useResize hook as illustrated in the current documentation, I encountered an error stating that an argument was expected by useResize, but none was provided. This was specifically related to the initial usage example

```jsx
const { width, height } = useResize();
return <animated.div style={{ width, height }}>Hello World</animated.div>
```

This led to some confusion, as it was not immediately clear that useResize requires at least one argument to function correctly.

### What

To make it easier for people who use the useResize Hook to understand, we have modified the Usage example code.

### Checklist

- [x] Documentation updated
- [ ] Demo added
- [x] Ready to be merged

If there are any changes I need to make to my code, I would appreciate your feedback.
