### PR TITLE
fix(#2173): add explicit dep for @react-spring/rafz for yarn and pnpm

### DIFF
--- a/.changeset/unlucky-humans-beg.md
+++ b/.changeset/unlucky-humans-beg.md
@@ -1,0 +1,5 @@
+---
+"react-spring": patch
+---
+
+Add explicit dependency on @react-spring/rafz for pnpm and yarn

--- a/packages/react-spring/package.json
+++ b/packages/react-spring/package.json
@@ -39,6 +39,7 @@
     "@react-spring/core": "~9.7.3",
     "@react-spring/konva": "~9.7.3",
     "@react-spring/native": "~9.7.3",
+    "@react-spring/rafz": "~9.7.3",
     "@react-spring/three": "~9.7.3",
     "@react-spring/web": "~9.7.3",
     "@react-spring/zdog": "~9.7.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5219,7 +5219,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@react-spring/rafz@workspace:^, @react-spring/rafz@workspace:packages/rafz":
+"@react-spring/rafz@workspace:^, @react-spring/rafz@workspace:packages/rafz, @react-spring/rafz@~9.7.3":
   version: 0.0.0-use.local
   resolution: "@react-spring/rafz@workspace:packages/rafz"
   languageName: unknown
@@ -18937,6 +18937,7 @@ __metadata:
     "@react-spring/core": ~9.7.3
     "@react-spring/konva": ~9.7.3
     "@react-spring/native": ~9.7.3
+    "@react-spring/rafz": ~9.7.3
     "@react-spring/three": ~9.7.3
     "@react-spring/web": ~9.7.3
     "@react-spring/zdog": ~9.7.3


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

#2173 points out that TypeScript types for `@react-spring/web` depend on `@react-spring/rafz`. In Yarn 4 with PnP enabled (and maybe pnpm with no-hoist enabled), this requires the user to explicitly import or override dependencies for `@react-spring/web`.

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

### What

<!-- what have you done, if its a bug, whats your solution? -->
This PR adds the TypeScript dependency explicitly.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [X] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
Closes #2173 
