### PR TITLE
fix: useTransition hook works correctly with a function argument. (#2287)

### DIFF
--- a/packages/core/src/hooks/useTransition.tsx
+++ b/packages/core/src/hooks/useTransition.tsx
@@ -422,7 +422,9 @@ export function useTransition(
             }
           }
         }
-      )
+      );
+
+      if (ref) ref.start();
     },
     reset ? void 0 : deps
   )


### PR DESCRIPTION



<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why
https://github.com/pmndrs/react-spring/issues/2287.
The useTransition hook doesn't work correctly if we pass a function as an argument.


### What

If we pass a function to the hook, a `ref` variable will be created, an instance of `SpringRef`.
Then, as stated in the comment, if the `ref` exists, the update is postponed until the `ref`'s `start` method is called. By calling the ctrl `update` method, we simply put another item in the queue. Perhaps I didn’t fully understand it, but I didn’t see calling the `start` method on an existing `ref` that flushes the queue.

Calling the `ref`'s `start` method in useIsomorphicLayoutEffect solves the problem.


![image](https://github.com/pmndrs/react-spring/assets/38655430/9940b813-04c2-4f80-91cd-bb1f35c69ce8)


### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Demo added
- [ ] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
