### PR TITLE
support removing attributes from animated elements

### DIFF
--- a/.changeset/animate-attribute-removal.md
+++ b/.changeset/animate-attribute-removal.md
@@ -1,0 +1,5 @@
+---
+'@react-spring/web': patch
+---
+
+fix: support removing attributes from animated elements

--- a/targets/web/src/applyAnimatedValues.ts
+++ b/targets/web/src/applyAnimatedValues.ts
@@ -78,7 +78,11 @@ export function applyAnimatedValues(instance: Instance, props: Lookup) {
     instance.scrollLeft = scrollLeft
   }
   if (props.hasOwnProperty('viewBox')) {
-    instance.setAttribute('viewBox', viewBox)
+    if (viewBox !== void 0) {
+      instance.setAttribute('viewBox', viewBox)
+    } else {
+      instance.removeAttribute('viewBox')
+    }
   }
 }
 

--- a/targets/web/src/applyAnimatedValues.ts
+++ b/targets/web/src/applyAnimatedValues.ts
@@ -22,7 +22,7 @@ const attributeCache: Lookup<string> = {}
 type Instance = HTMLDivElement & { style?: Lookup }
 
 export function applyAnimatedValues(instance: Instance, props: Lookup) {
-  if (!instance.nodeType || !instance.setAttribute) {
+  if (!instance.nodeType || !instance.setAttribute || !instance.removeAttribute) {
     return false
   }
 
@@ -45,7 +45,7 @@ export function applyAnimatedValues(instance: Instance, props: Lookup) {
         ))
   )
 
-  if (children !== void 0) {
+  if (props.hasOwnProperty('children')) {
     instance.textContent = children
   }
 
@@ -63,7 +63,12 @@ export function applyAnimatedValues(instance: Instance, props: Lookup) {
 
   // Apply DOM attributes
   names.forEach((name, i) => {
-    instance.setAttribute(name, values[i])
+    const value = values[i]
+    if (value !== void 0) {
+      instance.setAttribute(name, value)
+    } else {
+      instance.removeAttribute(name)
+    }
   })
 
   if (scrollTop !== void 0) {
@@ -72,7 +77,7 @@ export function applyAnimatedValues(instance: Instance, props: Lookup) {
   if (scrollLeft !== void 0) {
     instance.scrollLeft = scrollLeft
   }
-  if (viewBox !== void 0) {
+  if (props.hasOwnProperty('viewBox')) {
     instance.setAttribute('viewBox', viewBox)
   }
 }


### PR DESCRIPTION
### Why

[`inert`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inert) does not accept `inert=''`, `inert='false'`, `inert='undefined'` or etc. The attribute ***must*** be entirely removed in order to enable the element again. [`disabled` works the same way](https://developer.mozilla.org/en-US/docs/Web/API/Element/setAttribute).

### What

If a value resolves to `undefined` (not `null` or `false` or otherwise) its attribute will now be entirely removed.

### Checklist

- [x] Ready to be merged