### PR TITLE
fix: add `useReducedMotion` compatibility for Safari 13 and older

### DIFF
--- a/.changeset/stale-owls-double.md
+++ b/.changeset/stale-owls-double.md
@@ -1,0 +1,5 @@
+---
+'@react-spring/shared': minor
+---
+
+fix: MediaQueryList.addListener safari 13 (and older) compatibility

--- a/.changeset/stale-owls-double.md
+++ b/.changeset/stale-owls-double.md
@@ -1,5 +1,5 @@
 ---
-'@react-spring/shared': minor
+'@react-spring/shared': patch
 ---
 
 fix: MediaQueryList.addListener safari 13 (and older) compatibility

--- a/packages/shared/src/hooks/useReducedMotion.ts
+++ b/packages/shared/src/hooks/useReducedMotion.ts
@@ -26,10 +26,18 @@ export const useReducedMotion = () => {
 
     handleMediaChange(mql)
 
-    mql.addEventListener('change', handleMediaChange)
+    if(mql.addEventListener) {
+      mql.addEventListener('change', handleMediaChange)
+    } else {
+      mql.addListener(handleMediaChange)
+    }
 
     return () => {
-      mql.removeEventListener('change', handleMediaChange)
+      if(mql.removeEventListener) {
+        mql.removeEventListener('change', handleMediaChange)
+      } else {
+        mql.removeListener(handleMediaChange)
+      }
     }
   }, [])
 

--- a/packages/shared/src/hooks/useReducedMotion.ts
+++ b/packages/shared/src/hooks/useReducedMotion.ts
@@ -26,14 +26,14 @@ export const useReducedMotion = () => {
 
     handleMediaChange(mql)
 
-    if(mql.addEventListener) {
+    if (mql.addEventListener) {
       mql.addEventListener('change', handleMediaChange)
     } else {
       mql.addListener(handleMediaChange)
     }
 
     return () => {
-      if(mql.removeEventListener) {
+      if (mql.removeEventListener) {
         mql.removeEventListener('change', handleMediaChange)
       } else {
         mql.removeListener(handleMediaChange)


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

Currently, calling `useReducedMotion` on a Safari browser older than v14 causes an error, crashing the app.
This pull request adds compatibility checks, so that `useReducedMotion` can be called on older devices without producing an error.

Resolves https://github.com/pmndrs/react-spring/issues/2299

### What

Adds truthy checks to `MediaQueryList.addEventListener` before attempting to call the function. This function is undefined on older browsers.
<!-- what have you done, if its a bug, whats your solution? -->

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
