### PR TITLE
fix(core): Added threshold field to IntersectionArgs for useInView hook

### DIFF
--- a/.changeset/good-elephants-matter.md
+++ b/.changeset/good-elephants-matter.md
@@ -1,0 +1,5 @@
+---
+'@react-spring/core': patch
+---
+
+Added threshold field to IntersectionArgs for useInView hook

--- a/docs/app/routes/docs.utilities.use-in-view.mdx
+++ b/docs/app/routes/docs.utilities.use-in-view.mdx
@@ -100,7 +100,7 @@ The reference below describes the return value of the optional function argument
 
 ```tsx
 interface IntersectionArgs
-  extends Omit<IntersectionObserverInit, 'root' | 'threshold'> {
+  extends Omit<IntersectionObserverInit, 'root'> {
   root?: React.MutableRefObject<HTMLElement>
   once?: boolean
   amount?: 'any' | 'all' | number | number[]

--- a/packages/core/src/hooks/useInView.ts
+++ b/packages/core/src/hooks/useInView.ts
@@ -7,7 +7,7 @@ import { useSpring, UseSpringProps } from './useSpring'
 import { Valid } from '../types/common'
 
 export interface IntersectionArgs
-  extends Omit<IntersectionObserverInit, 'root' | 'threshold'> {
+  extends Omit<IntersectionObserverInit, 'root'> {
   root?: React.MutableRefObject<HTMLElement>
   once?: boolean
   amount?: 'any' | 'all' | number | number[]


### PR DESCRIPTION
### Why

According to [doc](https://www.react-spring.dev/docs/utilities/use-in-view) `useInView` must accept field `threshold`, but there is type error

### What

fix types

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->
