### PR TITLE
fix: update document edit page links

### DIFF
--- a/docs/app/helpers/links.ts
+++ b/docs/app/helpers/links.ts
@@ -13,7 +13,7 @@ export const getDocFilePathToGithub = (item?: FlattenedNavigation): string => {
   if (!filePath) {
     filePath = '_index'
   } else {
-    filePath = filePath.split('.').join('')
+    filePath = filePath.replace(/\//g, '.')
   }
 
   if (item.hasChildren) {


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->
This change resolves the issue where the 'Edit this page' button links to incorrect GitHub paths, resulting in 404 error pages. The current links do not accurately reflect the correct file structure.
### What

<!-- what have you done, if its a bug, whats your solution? -->
- Modified the `getDocFilePathToGithub` function to generate correct GitHub edit URLs.
- Implemented logic to create accurate file paths based on the active route.
- Converted path slashes (/) to dots (.) to match the actual file structure.

### BEFORE
https://github.com/user-attachments/assets/180bc9e9-4479-4dd8-bc95-aa260b7b8def

### AFTER
https://github.com/user-attachments/assets/49e7e2de-104a-4730-a09f-dda58d0f0fc7

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [x] Demo added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
