### PR TITLE
Fix repository field format in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "react-spring--root",
   "private": true,
   "description": "Cross-platform animation engine for React",
-  "repository": "pmndrs/react-spring",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pmndrs/react-spring.git"
+  },
   "homepage": "https://github.com/pmndrs/react-spring#readme",
   "keywords": [
     "animated",

--- a/packages/animated/package.json
+++ b/packages/animated/package.json
@@ -23,7 +23,10 @@
     "README.md",
     "LICENSE"
   ],
-  "repository": "pmndrs/react-spring",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pmndrs/react-spring.git"
+  },
   "homepage": "https://github.com/pmndrs/react-spring#readme",
   "keywords": [
     "animated",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,7 +22,10 @@
     "README.md",
     "LICENSE"
   ],
-  "repository": "pmndrs/react-spring",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pmndrs/react-spring.git"
+  },
   "homepage": "https://github.com/pmndrs/react-spring#readme",
   "funding": {
     "type": "opencollective",

--- a/packages/parallax/package.json
+++ b/packages/parallax/package.json
@@ -22,7 +22,10 @@
     "README.md",
     "LICENSE"
   ],
-  "repository": "pmndrs/react-spring",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pmndrs/react-spring.git"
+  },
   "homepage": "https://github.com/pmndrs/react-spring#readme",
   "keywords": [
     "animated",

--- a/packages/rafz/package.json
+++ b/packages/rafz/package.json
@@ -23,7 +23,10 @@
     "README.md",
     "LICENSE"
   ],
-  "repository": "pmndrs/react-spring",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pmndrs/react-spring.git"
+  },
   "homepage": "https://github.com/pmndrs/react-spring/tree/main/packages/rafz#readme",
   "keywords": [
     "animated",

--- a/packages/react-spring/package.json
+++ b/packages/react-spring/package.json
@@ -22,7 +22,10 @@
     "README.md",
     "LICENSE"
   ],
-  "repository": "pmndrs/react-spring",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pmndrs/react-spring.git"
+  },
   "homepage": "https://github.com/pmndrs/react-spring#readme",
   "keywords": [
     "animated",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -23,7 +23,10 @@
     "README.md",
     "LICENSE"
   ],
-  "repository": "pmndrs/react-spring",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pmndrs/react-spring.git"
+  },
   "homepage": "https://github.com/pmndrs/react-spring#readme",
   "keywords": [
     "animated",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -23,7 +23,10 @@
     "README.md",
     "LICENSE"
   ],
-  "repository": "pmndrs/react-spring",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pmndrs/react-spring.git"
+  },
   "homepage": "https://github.com/pmndrs/react-spring#readme",
   "keywords": [
     "animated",

--- a/targets/konva/package.json
+++ b/targets/konva/package.json
@@ -22,7 +22,10 @@
     "README.md",
     "LICENSE"
   ],
-  "repository": "pmndrs/react-spring",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pmndrs/react-spring.git"
+  },
   "homepage": "https://github.com/pmndrs/react-spring#readme",
   "keywords": [
     "animated",

--- a/targets/native/package.json
+++ b/targets/native/package.json
@@ -22,7 +22,10 @@
     "README.md",
     "LICENSE"
   ],
-  "repository": "pmndrs/react-spring",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pmndrs/react-spring.git"
+  },
   "homepage": "https://github.com/pmndrs/react-spring#readme",
   "keywords": [
     "animated",

--- a/targets/three/package.json
+++ b/targets/three/package.json
@@ -22,7 +22,10 @@
     "README.md",
     "LICENSE"
   ],
-  "repository": "pmndrs/react-spring",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pmndrs/react-spring.git"
+  },
   "homepage": "https://github.com/pmndrs/react-spring#readme",
   "keywords": [
     "animated",

--- a/targets/web/package.json
+++ b/targets/web/package.json
@@ -22,7 +22,10 @@
     "README.md",
     "LICENSE"
   ],
-  "repository": "pmndrs/react-spring",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pmndrs/react-spring.git"
+  },
   "homepage": "https://github.com/pmndrs/react-spring#readme",
   "keywords": [
     "animated",

--- a/targets/zdog/package.json
+++ b/targets/zdog/package.json
@@ -22,7 +22,10 @@
     "README.md",
     "LICENSE"
   ],
-  "repository": "pmndrs/react-spring",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pmndrs/react-spring.git"
+  },
   "homepage": "https://github.com/pmndrs/react-spring#readme",
   "keywords": [
     "animated",


### PR DESCRIPTION
# what

This PR updates the "repository" field in package.json to use the standard format.

# why
- Aligns with the recommended npm package.json repository format.
- Ensuring compatibility with [tools](https://npm-compare.com/react-spring/#timeRange=THREE_YEARS) that rely on the standard format metadata.


