### PR TITLE
Clarify what `immediate` does

### DIFF
--- a/docs/app/data/fixtures.tsx
+++ b/docs/app/data/fixtures.tsx
@@ -517,7 +517,7 @@ export const USESPRINGVALUE_CONFIG_DATA: CellData[][] = [
   [
     {
       label: 'immediate',
-      content: <p>Prevents the animation if true.</p>,
+      content: <p>Prevents the animation if true, applying the `to` styles immediately.</p>,
     },
     {
       label: 'boolean | function',

--- a/docs/app/data/fixtures.tsx
+++ b/docs/app/data/fixtures.tsx
@@ -517,7 +517,11 @@ export const USESPRINGVALUE_CONFIG_DATA: CellData[][] = [
   [
     {
       label: 'immediate',
-      content: <p>Prevents the animation if true, applying the `to` styles immediately.</p>,
+      content: (
+        <p>
+          Prevents the animation if true, applying the `to` styles immediately.
+        </p>
+      ),
     },
     {
       label: 'boolean | function',


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

The naming of `immediate` _suggests_ target styles will be applied instead of running the animation, but this isn't explicitly stated. This makes me unsure of whether I should be using `immediate` when wanting to skip motion.

### What

Clarifies what `immediate` does to 'prevent' animation

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Documentation updated
- [ ] Demo added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
