### PR TITLE
fix: spring does not start

### DIFF
--- a/packages/core/src/hooks/useSprings.test.tsx
+++ b/packages/core/src/hooks/useSprings.test.tsx
@@ -29,7 +29,7 @@ describe('useSprings', () => {
     it('should reach final value in strict mode', async () => {
       update(1, () => ({
         from: { x: 0 },
-        to: { x: 1 }
+        to: { x: 1 },
       }))
       expect(mapSprings(s => s.goal)).toEqual([{ x: 1 }])
     })

--- a/packages/core/src/hooks/useSprings.test.tsx
+++ b/packages/core/src/hooks/useSprings.test.tsx
@@ -26,6 +26,14 @@ describe('useSprings', () => {
   }, isStrictMode)
 
   describe('when only a props function is passed', () => {
+    it('should reach final value in strict mode', async () => {
+      update(1, () => ({
+        from: { x: 0 },
+        to: { x: 1 }
+      }))
+      expect(mapSprings(s => s.goal)).toEqual([{ x: 1 }])
+    })
+
     it('calls the props function once per new spring', () => {
       const getProps = jest.fn((i: number) => ({ x: i * 100 }))
 

--- a/packages/core/src/hooks/useSprings.ts
+++ b/packages/core/src/hooks/useSprings.ts
@@ -218,7 +218,6 @@ export function useSprings(
           ctrl.start(update)
         }
       }
-      updates.current[i] = null
     })
   })
 

--- a/packages/core/src/hooks/useSprings.ts
+++ b/packages/core/src/hooks/useSprings.ts
@@ -127,6 +127,10 @@ export function useSprings(
     []
   )
 
+  // useRef is needed to get the same references accross renders.
+  // Note that controllers are a shallow copy of the final array.
+  // So any array manipulation won't impact the final array until
+  // the commit phase, in the useIsomorphicLayoutEffect callback
   const ctrls = useRef([...state.ctrls])
   const updates = useRef<any[]>([])
 
@@ -180,6 +184,10 @@ export function useSprings(
   const prevContext = usePrev(context)
   const hasContext = context !== prevContext && hasProps(context)
 
+  // This is the commit phase where the new transition will begin.
+  // - updated animation values will be passed to the controlers.
+  // - state will be updated
+  // - springs will start or the new update will be queued if the spring is not started yet.
   useIsomorphicLayoutEffect(() => {
     layoutId.current++
 

--- a/packages/core/src/hooks/useSprings.ts
+++ b/packages/core/src/hooks/useSprings.ts
@@ -129,7 +129,6 @@ export function useSprings(
 
   const ctrls = useRef([...state.ctrls])
   const updates = useRef<any[]>([])
-  updates.current ??= []
 
   // Cache old controllers to dispose in the commit phase.
   const prevLength = usePrev(length) || 0


### PR DESCRIPTION
### Why

This PR fixes a bug where useSpring lead to unmount component (eg. blank page)

Related: #2371

### What

The root cause was an instruction which removes the current update during the useIsomorphicLayoutEffect callback.

@kierancap I would like your opinion on this if you have a minute. I don't know exactly the impact of this.

### Checklist

- [x] Demo added: check before/after the demo css-variables
- [x] Ready to be merged