### PR TITLE
fix: remove accessing elem.ref in renderTransitions

### DIFF
--- a/packages/core/src/hooks/useTransition.tsx
+++ b/packages/core/src/hooks/useTransition.tsx
@@ -433,18 +433,18 @@ export function useTransition(
         const { springs } = changes.get(t) || t.ctrl
         const elem: any = render({ ...springs }, t.item, t, i)
 
-        if (!elem || !elem.type) return elem
-
         const key = is.str(t.key) || is.num(t.key) ? t.key : t.ctrl.id
         const isLegacyReact = React.version < '19.0.0'
 
-        return (
-          <elem.type
-            {...elem.props}
-            key={key}
-            {...(isLegacyReact && { ref: elem.ref })}
-          />
-        )
+        const props = {
+          ...elem.props,
+        }
+
+        if (isLegacyReact) {
+          props.ref = elem.ref
+        }
+
+        return elem && elem.type ? <elem.type key={key} {...props} /> : elem
       })}
     </>
   )

--- a/packages/core/src/hooks/useTransition.tsx
+++ b/packages/core/src/hooks/useTransition.tsx
@@ -432,14 +432,18 @@ export function useTransition(
       {transitions.map((t, i) => {
         const { springs } = changes.get(t) || t.ctrl
         const elem: any = render({ ...springs }, t.item, t, i)
-        return elem && elem.type ? (
+
+        if (!elem || !elem.type) return elem
+
+        const key = is.str(t.key) || is.num(t.key) ? t.key : t.ctrl.id
+        const isLegacyReact = React.version < '19.0.0'
+
+        return (
           <elem.type
             {...elem.props}
-            key={is.str(t.key) || is.num(t.key) ? t.key : t.ctrl.id}
-            ref={React.version < '19.0.0' ? elem.ref : elem.props.ref}
+            key={key}
+            {...(isLegacyReact && { ref: elem.ref })}
           />
-        ) : (
-          elem
         )
       })}
     </>

--- a/packages/core/src/hooks/useTransition.tsx
+++ b/packages/core/src/hooks/useTransition.tsx
@@ -436,7 +436,6 @@ export function useTransition(
           <elem.type
             {...elem.props}
             key={is.str(t.key) || is.num(t.key) ? t.key : t.ctrl.id}
-            ref={elem.ref}
           />
         ) : (
           elem

--- a/packages/core/src/hooks/useTransition.tsx
+++ b/packages/core/src/hooks/useTransition.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import { version as reactVersion } from 'react/package.json'
 import { useContext, useRef, useMemo } from 'react'
 import { Lookup, OneOrMore, UnknownProps } from '@react-spring/types'
 import {
@@ -436,6 +437,7 @@ export function useTransition(
           <elem.type
             {...elem.props}
             key={is.str(t.key) || is.num(t.key) ? t.key : t.ctrl.id}
+            ref={reactVersion < '19.0.0' ? elem.ref : elem.props.ref}
           />
         ) : (
           elem

--- a/packages/core/src/hooks/useTransition.tsx
+++ b/packages/core/src/hooks/useTransition.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react'
-import { version as reactVersion } from 'react/package.json'
 import { useContext, useRef, useMemo } from 'react'
 import { Lookup, OneOrMore, UnknownProps } from '@react-spring/types'
 import {
@@ -437,7 +436,7 @@ export function useTransition(
           <elem.type
             {...elem.props}
             key={is.str(t.key) || is.num(t.key) ? t.key : t.ctrl.id}
-            ref={reactVersion < '19.0.0' ? elem.ref : elem.props.ref}
+            ref={React.version < '19.0.0' ? elem.ref : elem.props.ref}
           />
         ) : (
           elem

--- a/packages/core/src/hooks/useTransition.tsx
+++ b/packages/core/src/hooks/useTransition.tsx
@@ -436,9 +436,7 @@ export function useTransition(
         const key = is.str(t.key) || is.num(t.key) ? t.key : t.ctrl.id
         const isLegacyReact = React.version < '19.0.0'
 
-        const props = {
-          ...elem.props,
-        }
+        const props = elem?.props ?? {}
 
         if (isLegacyReact) {
           props.ref = elem.ref

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,6 +26,7 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "resolveJsonModule": true
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,6 @@
     "allowSyntheticDefaultImports": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "strictNullChecks": true,
-    "resolveJsonModule": true
+    "strictNullChecks": true
   }
 }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

<!-- What changes are being made? What feature/bug is being fixed here? If you are closing an issue, use the keyword 'resolves' to link the issue automatically -->

Accessing element.ref is deprecated. Refs are now regular props and should be accessed using element.props.ref. Accessing element.ref produces a web console error.

https://react.dev/blog/2024/04/25/react-19-upgrade-guide#deprecated-element-ref

### What

<!-- what have you done, if its a bug, whats your solution? -->

Removed accessing elem.ref in useTransition.tsx. Props are already spreaded.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Demo added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
