### PR TITLE
Support immediate useResize

### DIFF
--- a/.changeset/hot-socks-whisper.md
+++ b/.changeset/hot-socks-whisper.md
@@ -1,0 +1,5 @@
+---
+'@react-spring/core': patch
+---
+
+Respect `immediate` option to `useResize` hook

--- a/packages/core/src/hooks/useResize.ts
+++ b/packages/core/src/hooks/useResize.ts
@@ -57,7 +57,9 @@ export const useResize = ({
           width,
           height,
           immediate:
-            sizeValues.width.get() === 0 || sizeValues.height.get() === 0,
+            sizeValues.width.get() === 0 ||
+            sizeValues.height.get() === 0 ||
+            springOptions.immediate === true,
         })
       },
       { container: container?.current || undefined }


### PR DESCRIPTION
### Why

I'm already using an interpolation to transition between two container heights, so I don't need the heights themselves to animate.

### What

Before this PR, when `useResize` is used like `useResize({ container: thingRef, immediate: true })` it just ignores the `immediate` option, even though TypeScript suggests that `immediate` should work.

This PR makes `useResize` respect that option if it is passed.

### Checklist

- [ ] Documentation updated: N/A; the types already suggest this is possible
- [ ] Demo added: N/A; I don't think this should need an example
- [x] Ready to be merged