### PR TITLE
fix: fix `useTransition` when working with React 18

### DIFF
--- a/packages/core/src/hooks/useTransition.tsx
+++ b/packages/core/src/hooks/useTransition.tsx
@@ -436,9 +436,9 @@ export function useTransition(
         const key = is.str(t.key) || is.num(t.key) ? t.key : t.ctrl.id
         const isLegacyReact = React.version < '19.0.0'
 
-        const props = elem?.props ?? {}
+        const props = { ...elem?.props }
 
-        if (isLegacyReact) {
+        if (isLegacyReact && elem && elem.type) {
           props.ref = elem.ref
         }
 


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

Hello :) 

### Why

This is a PR to fix the issue that I've opened https://github.com/pmndrs/react-spring/issues/2395

### What

There are some problems after the change made here https://github.com/pmndrs/react-spring/pull/2373/files#diff-3dce88b788d6e5008705461509e6c3a027695ca9a198d918b9d9c4800d4d2181R441 when working with React 18

### Checklist

ps: the command `yarn changeset:add` does not seem to work. It seems `yarn changeset` adds the changeset file, should I add it? (I see that some PRs are merged without changeset file)

<img width="742" height="68" alt="Not working changeset command" src="https://github.com/user-attachments/assets/15f967e7-6aa7-41f9-a950-f03530f8f502" />


<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [ ] Documentation updated
- [ ] Demo added
- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
