### PR TITLE
fix: exitBeforeEnter in useTransition doesn't work when used with trail (#1868)

### DIFF
--- a/.changeset/gentle-tomatoes-nail.md
+++ b/.changeset/gentle-tomatoes-nail.md
@@ -1,0 +1,5 @@
+---
+'@react-spring/core': patch
+---
+
+fix: exitBeforeEnter in useTransition doesn't work when used with trail

--- a/packages/core/src/hooks/useTransition.test.tsx
+++ b/packages/core/src/hooks/useTransition.test.tsx
@@ -195,6 +195,36 @@ describe('useTransition', () => {
 
     expect(rendered).toEqual([1])
   })
+
+  it('should work with both exitBeforeEnter and trail together', async () => {
+    const props = {
+      from: { t: 0 },
+      enter: { t: 1 },
+      leave: { t: 0 },
+      exitBeforeEnter: true,
+      trail: 100,
+    }
+
+    // Start with two items
+    update([0, 1], props)
+    expect(rendered).toEqual([0, 1])
+
+    global.mockRaf.step()
+
+    // Replace with two new items - the old ones should leave first with trail
+    update([2, 3], props)
+
+    global.mockRaf.step()
+
+    // Old items should still be visible (leaving with trail)
+    expect(rendered).toEqual([0, 1])
+
+    // Wait for all leave animations to complete
+    await global.advanceUntilIdle()
+
+    // New items should now be visible
+    expect(rendered).toEqual([2, 3])
+  })
 })
 
 let result: RenderResult | undefined

--- a/packages/core/src/hooks/useTransition.tsx
+++ b/packages/core/src/hooks/useTransition.tsx
@@ -307,6 +307,9 @@ export function useTransition(
       if (t.ctrl.idle) {
         const idle = transitions.every(t => t.ctrl.idle)
         if (t.phase == TransitionPhase.LEAVE) {
+          // Remove this transition from exitingTransitions as soon as it completes.
+          exitingTransitions.current.delete(t)
+
           const expiry = callProp(expires, t.item)
           if (expiry !== false) {
             const expiryMs = expiry === true ? 0 : expiry
@@ -323,12 +326,6 @@ export function useTransition(
         }
         // Force update once idle and expired items exist.
         if (idle && transitions.some(t => t.expired)) {
-          /**
-           * Remove the exited transition from the list
-           * this may not exist but we'll try anyway.
-           */
-          exitingTransitions.current.delete(t)
-
           if (exitBeforeEnter) {
             /**
              * If we have exitBeforeEnter == true


### PR DESCRIPTION
### Why

Fixes #1868

### What

When `trail` and `exitBeforeEnter` are used together, only the last of the leave transitions was being removed from `exitingTransitions`. (See useTransition.tsx:330) On re-render, the other transitions which remained in `exitingTransitions` meant enter animations would not play.

Instead I am now clearing each transition as it completes. Essentially I just moved the `delete()` statement into the `t.phase == TransitionPhase.LEAVE` block so that it runs for every leaving transition rather than waiting for idle.

I also added a new test. To verify the fix you can pull this commit, remove the fix, and run the test. It will fail. With the fix in place, it passes. No other tests fail and my visual tests in my app show that things still work.

### Checklist

- [x] Documentation updated
- [x] Demo added
- [x] Ready to be merged

I don't think documentation needs to be updated or a demo needs to be added for this bugfix