### PR TITLE
fix(core): clear stale updates in useSprings layout effect

### DIFF
--- a/.changeset/fix-stale-useSprings-updates.md
+++ b/.changeset/fix-stale-useSprings-updates.md
@@ -1,0 +1,5 @@
+---
+'@react-spring/core': patch
+---
+
+fix(core): clear stale updates in useSprings layout effect to prevent re-application on subsequent renders

--- a/packages/core/src/hooks/useSprings.test.tsx
+++ b/packages/core/src/hooks/useSprings.test.tsx
@@ -78,6 +78,22 @@ describe('useSprings', () => {
       expect(springs.length).toBe(4)
       expect(ref.current.length).toBe(4)
     })
+
+    it('imperative start is not overridden by stale declarative updates on re-render', () => {
+      // Regression for #2376 / #2377: declarative initial values via props fn
+      // are stored in a ref during render and applied in the layout effect. If
+      // the ref is not cleared after applying, every subsequent re-render's
+      // layout effect re-applies them, clobbering imperative `ref.start(...)`
+      // targets and resetting the goal back to the initial value.
+      update(1, () => ({ x: 0 }))
+
+      ref.start({ x: 1 })
+      expect(mapSprings(s => s.goal)).toEqual([{ x: 1 }])
+
+      // Re-render — props fn unchanged, no new declarative updates expected.
+      update(1, () => ({ x: 0 }))
+      expect(mapSprings(s => s.goal)).toEqual([{ x: 1 }])
+    })
   })
 
   describe('when both a props function and a deps array are passed', () => {

--- a/packages/core/src/hooks/useSprings.ts
+++ b/packages/core/src/hooks/useSprings.ts
@@ -134,6 +134,16 @@ export function useSprings(
   const ctrls = useRef([...state.ctrls])
   const updates = useRef<any[]>([])
 
+  // Backup of the most recently applied updates. The layout effect drains
+  // `updates.current` after applying so a parent re-render with unchanged
+  // deps doesn't re-apply stale entries (see #2376). StrictMode mounts
+  // twice (mount → simulated unmount via `useOnce` cleanup → mount), and the
+  // second mount needs to restart the controllers after they've been stopped,
+  // so we keep this snapshot to fall back to. Reset each render so a snapshot
+  // from a previous commit can never bleed into a subsequent layout effect.
+  const strictModeRestartSnapshot = useRef<any[]>([])
+  strictModeRestartSnapshot.current = []
+
   // Cache old controllers to dispose in the commit phase.
   const prevLength = usePrev(length) || 0
 
@@ -201,6 +211,14 @@ export function useSprings(
       each(queue, cb => cb())
     }
 
+    // Fall back to the restart snapshot when the primary array has been
+    // consumed — this lets StrictMode's second mount re-apply updates after
+    // the simulated cleanup stops the controllers.
+    const activeUpdates =
+      updates.current.length > 0
+        ? updates.current
+        : strictModeRestartSnapshot.current
+
     // Update existing controllers.
     each(ctrls.current, (ctrl, i) => {
       // Attach the controller to the local ref.
@@ -212,7 +230,7 @@ export function useSprings(
       }
 
       // Apply updates created during render.
-      const update = updates.current[i]
+      const update = activeUpdates[i]
       if (update) {
         // Update the injected ref if needed.
         replaceRef(ctrl, update.ref)
@@ -234,6 +252,13 @@ export function useSprings(
         }
       }
     })
+
+    // Snapshot updates before clearing so StrictMode's second mount can
+    // still access them (see activeUpdates above).
+    if (updates.current.length > 0) {
+      strictModeRestartSnapshot.current = updates.current
+    }
+    updates.current = []
   })
 
   // Cancel the animations of all controllers on unmount.


### PR DESCRIPTION
## Summary

Fixes #2376

The `updates` ref in `useSprings` (introduced in #2368) accumulates declarative updates during the render phase. The layout effect processes these updates but never clears the ref afterward. On subsequent re-renders where no new updates are declared (i.e. `useMemo` is skipped because deps haven't changed), the stale entries persist in the ref and get re-applied, corrupting animation state.

## The fix

Clear `updates.current` at the end of the layout effect so that consumed updates are not carried over to the next render cycle.

A `committedUpdates` snapshot is kept so that React StrictMode's simulated unmount/remount can still re-apply updates after controllers are stopped during cleanup.

### How `committedUpdates` works

1. **Render phase** — `committedUpdates.current` is reset to `[]`. This ensures stale snapshots from a previous render are discarded.
2. **First layout effect** — `updates.current` has entries from `declareUpdates`. After processing, the array is copied into `committedUpdates.current` and then cleared.
3. **StrictMode cleanup** — `useOnce` stops all controllers via `ctrl.stop(true)`.
4. **Second layout effect** — `updates.current` is empty, so `activeUpdates` falls back to `committedUpdates.current`, allowing controllers to be restarted.

On the next real render, step 1 resets the snapshot, so no stale data survives across render boundaries.

## Changes

- `packages/core/src/hooks/useSprings.ts` — clear `updates.current` after commit; maintain `committedUpdates` for StrictMode
- `packages/core/src/hooks/useSprings.test.tsx` — regression test: re-render with unchanged deps must not re-apply stale updates

## Testing

- Added regression test (`does not re-apply stale updates on re-render with unchanged deps`)
- All existing tests pass (including StrictMode coverage)
- Verified in a production app using `@react-spring/three` with React 19 and React Three Fiber 9