### PR TITLE
chore(readme): fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ It's as simple as that to create scroll-in animations when value of `isVisible` 
 
 ### 📖 Documentation and Examples
 
-More documentation on the project can be found [here](https://www.react-spring.io).
+More documentation on the project can be found [here](https://www.react-spring.dev).
 
-Pages contain their own [examples](https://react-spring.io/hooks/use-spring#demos) which you can check out there, or [open in codesandbox](https://codesandbox.io/s/github/pmndrs/react-spring/tree/main/demo/src/sandboxes/card) for a more in-depth view!
+Pages contain their own [examples](https://www.react-spring.dev/docs/components/use-spring#examples) which you can check out there, or [open in codesandbox](https://codesandbox.io/s/github/pmndrs/react-spring/tree/main/demo/src/sandboxes/card) for a more in-depth view!
 
 ---
 


### PR DESCRIPTION
### Why

Wrong links. [react-spring.io](https://react-spring.io) gave me a chuckle though

### What

Fixed the links in readme, a simple copyedit

### Checklist

- [x] Documentation updated
- [ ] Demo added
- [x] Ready to be merged

