### PR TITLE
chore: migrate husky hooks to v9 syntax

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-npx --no-install commitlint --edit $1
+npx --no-install commitlint --edit "$1"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx --no-install oxfmt --check "**/*.{ts,tsx,md}"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lint": "oxlint packages/*/src targets/*/src docs/app docs/scripts demo/src",
     "package": "turbo run pack",
     "postinstall": "remix setup node",
-    "prepare": "husky install",
+    "prepare": "husky",
     "test": "pnpm test:ts && pnpm test:unit && pnpm test:e2e",
     "test:unit": "vitest run --project unit",
     "test:cov": "vitest run --project unit --coverage",


### PR DESCRIPTION
Silence husky v9 deprecation warnings by dropping the v8 `_/husky.sh` sourcing line from each hook and switching `prepare` from `husky install` to `husky`.