### PR TITLE
fix: replace react-spring.io with react-spring.dev

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,7 +14,7 @@ body:
         support or usage questions. Questions here don't have as much visibility as they do elsewhere. Before
         you ask a question, here are some resources to get help first:
 
-        - [Read the docs](https://react-spring.io)
+        - [Read the docs](https://react-spring.dev)
         - [Explore examples](https://github.com/pmndrs/reat-spring/tree/main/demo/src/sandbox)
         - Look for/ask questions on [Stack Overflow](https://stackoverflow.com/questions/ask?tags=react-spring)
         - Ask in [GitHub Discussions](https://github.com/pmndrs/react-spring/discussions)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -14,7 +14,7 @@ body:
         support or usage questions. Questions here don't have as much visibility as they do elsewhere. Before
         you ask a question, here are some resources to get help first:
 
-        - [Read the docs](https://react-spring.io)
+        - [Read the docs](https://react-spring.dev)
         - [Explore examples](https://github.com/pmndrs/reat-spring/tree/main/demo/src/sandbox)
         - Look for/ask questions on [Stack Overflow](https://stackoverflow.com/questions/ask?tags=react-spring)
         - Ask in [GitHub Discussions](https://github.com/pmndrs/react-spring/discussions)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ Finally:
 pnpm release
 ```
 
-This will build the packages, publish them & push the tags to github to signify a new release. Please then update the `releases` on github & the changelog on `react-spring.io`
+This will build the packages, publish them & push the tags to github to signify a new release. Please then update the `releases` on github & the changelog on `react-spring.dev`
 
 ## Prerelease
 

--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ It's as simple as that to create scroll-in animations when value of `isVisible` 
 
 ### 📖 Documentation and Examples
 
-More documentation on the project can be found [here](https://www.react-spring.io).
+More documentation on the project can be found [here](https://www.react-spring.dev).
 
-Pages contain their own [examples](https://react-spring.io/hooks/use-spring#demos) which you can check out there, or [open in codesandbox](https://codesandbox.io/s/github/pmndrs/react-spring/tree/main/demo/src/sandboxes/card) for a more in-depth view!
+Pages contain their own [examples](https://react-spring.dev/hooks/use-spring#demos) which you can check out there, or [open in codesandbox](https://codesandbox.io/s/github/pmndrs/react-spring/tree/main/demo/src/sandboxes/card) for a more in-depth view!
 
 ---
 

--- a/docs/app/components/Feedback/Feedback.tsx
+++ b/docs/app/components/Feedback/Feedback.tsx
@@ -197,7 +197,7 @@ const FeedbackButton = ({
                 href={
                   variant === 'upvote'
                     ? `https://twitter.com/intent/tweet?text=${encodeURIComponent(
-                        `I've found this #reactspring doc page helpful! https://react-spring.io/${location.pathname}`
+                        `I've found this #reactspring doc page helpful! https://react-spring.dev/${location.pathname}`
                       )}`
                     : 'https://github.com/pmndrs/react-spring/issues/new/choose'
                 }

--- a/packages/parallax/README.md
+++ b/packages/parallax/README.md
@@ -33,13 +33,13 @@ const Example = () => {
 
 ## Parallax
 
-| Property    | Type          | Description                                                                                             |
-| ----------- | ------------- | ------------------------------------------------------------------------------------------------------- |
-| pages       | number        | Total space of the container. Each page takes up 100% of the viewport.                                  |
-| config?     | SpringConfig  | The spring behavior. Defaults to `config.slow` (see [configs](https://react-spring.io/common/configs)). |
-| enabled?    | boolean       | Whether or not the content can be scrolled. Defaults to `true`.                                         |
-| horizontal? | boolean       | Whether or not the container scrolls horizontally. Defaults to `false`.                                 |
-| innerStyle? | CSSProperties | CSS object to style the inner `Parallax` wrapper (not the scrollable container)                         |
+| Property    | Type          | Description                                                                                              |
+| ----------- | ------------- | -------------------------------------------------------------------------------------------------------- |
+| pages       | number        | Total space of the container. Each page takes up 100% of the viewport.                                   |
+| config?     | SpringConfig  | The spring behavior. Defaults to `config.slow` (see [configs](https://react-spring.dev/common/configs)). |
+| enabled?    | boolean       | Whether or not the content can be scrolled. Defaults to `true`.                                          |
+| horizontal? | boolean       | Whether or not the container scrolls horizontally. Defaults to `false`.                                  |
+| innerStyle? | CSSProperties | CSS object to style the inner `Parallax` wrapper (not the scrollable container)                          |
 
 ### `ref` Properties
 

--- a/packages/react-spring/README.md
+++ b/packages/react-spring/README.md
@@ -76,9 +76,9 @@ It's as simple as that to create scroll-in animations when value of `isVisible` 
 
 ### 📖 Documentation and Examples
 
-More documentation on the project can be found [here](https://www.react-spring.io).
+More documentation on the project can be found [here](https://www.react-spring.dev).
 
-Pages contain their own [examples](https://react-spring.io/hooks/use-spring#demos) which you can check out there, or [open in codesandbox](https://codesandbox.io/s/github/pmndrs/react-spring/tree/main/demo/src/sandboxes/card) for a more in-depth view!
+Pages contain their own [examples](https://react-spring.dev/hooks/use-spring#demos) which you can check out there, or [open in codesandbox](https://codesandbox.io/s/github/pmndrs/react-spring/tree/main/demo/src/sandboxes/card) for a more in-depth view!
 
 ---
 


### PR DESCRIPTION
The docs site has moved to react-spring.dev — update all README, docs, and issue-template links so they no longer point at the dead .io domain.

* Closes #2420
* Closes #2411
* Closes #2418