### PR TITLE
chore: add release PR workflow and npm provenance

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,11 +1,14 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@1.6.0/schema.json",
-  "changelog": false,
+  "changelog": [
+    "@changesets/changelog-github",
+    { "repo": "pmndrs/react-spring" }
+  ],
   "commit": false,
   "fixed": [["@react-spring/*"]],
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "next",
   "updateInternalDependencies": "patch",
   "ignore": ["@react-spring/demo", "@react-spring/docs"]
 }

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -16,6 +16,9 @@ jobs:
     name: 'Experimental Release'
     if: github.repository == 'pmndrs/react-spring'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.12.1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -17,6 +17,9 @@ jobs:
     name: 'Nightly Release'
     if: github.repository == 'pmndrs/react-spring'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
     outputs:
       NEXT_VERSION: ${{ steps.version.outputs.NEXT_VERSION }}
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - 'next'
+  workflow_dispatch:
 
 env:
   TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -35,13 +35,13 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: Setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version-file: '.nvmrc'
           cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
 
-      # npm Trusted Publishing requires npm >= 11.5.1; Node 20 ships npm 10.x
+      # npm Trusted Publishing requires npm >= 11.5.1; Node 22 LTS still ships npm 10.x
       - name: Upgrade npm
         run: npm install -g npm@latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,21 +51,6 @@ jobs:
       - name: Build
         run: pnpm build-ci
 
-      - name: Type-check
-        run: pnpm test:ts
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
-
-      - name: Install Playwright Chromium
-        run: pnpm exec playwright install --with-deps chromium
-
-      - name: Unit tests
-        run: pnpm test:unit
-
       - name: Create release PR or publish
         uses: changesets/action@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,76 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - 'next'
+
+env:
+  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  release:
+    name: 'Release'
+    if: github.repository == 'pmndrs/react-spring'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      id-token: write
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      # npm Trusted Publishing requires npm >= 11.5.1; Node 20 ships npm 10.x
+      - name: Upgrade npm
+        run: npm install -g npm@latest
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build-ci
+
+      - name: Type-check
+        run: pnpm test:ts
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Unit tests
+        run: pnpm test:unit
+
+      - name: Create release PR or publish
+        uses: changesets/action@v1
+        with:
+          version: pnpm vers
+          publish: pnpm changeset publish
+          title: 'chore: version packages'
+          commit: 'chore: version packages'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     }
   },
   "devDependencies": {
+    "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "2.27.11",
     "@commitlint/cli": "19.6.1",
     "@commitlint/config-conventional": "19.6.0",

--- a/packages/animated/package.json
+++ b/packages/animated/package.json
@@ -44,6 +44,9 @@
   "maintainers": [
     "Josh Ellis (https://github.com/joshuaellis)"
   ],
+  "publishConfig": {
+    "provenance": true
+  },
   "scripts": {
     "build": "tsup",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,6 +47,9 @@
   "maintainers": [
     "Josh Ellis (https://github.com/joshuaellis)"
   ],
+  "publishConfig": {
+    "provenance": true
+  },
   "scripts": {
     "build": "tsup",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",

--- a/packages/parallax/package.json
+++ b/packages/parallax/package.json
@@ -43,6 +43,9 @@
   "maintainers": [
     "Josh Ellis (https://github.com/joshuaellis)"
   ],
+  "publishConfig": {
+    "provenance": true
+  },
   "scripts": {
     "build": "tsup",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",

--- a/packages/rafz/package.json
+++ b/packages/rafz/package.json
@@ -41,6 +41,9 @@
   ],
   "license": "MIT",
   "author": "Josh Ellis",
+  "publishConfig": {
+    "provenance": true
+  },
   "scripts": {
     "build": "tsup",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",

--- a/packages/react-spring/package.json
+++ b/packages/react-spring/package.json
@@ -43,6 +43,9 @@
   "maintainers": [
     "Josh Ellis (https://github.com/joshuaellis)"
   ],
+  "publishConfig": {
+    "provenance": true
+  },
   "dependencies": {
     "@react-spring/core": "~10.0.3",
     "@react-spring/konva": "~10.0.3",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -44,6 +44,9 @@
   "maintainers": [
     "Josh Ellis (https://github.com/joshuaellis)"
   ],
+  "publishConfig": {
+    "provenance": true
+  },
   "dependencies": {
     "@react-spring/rafz": "~10.0.3",
     "@react-spring/types": "~10.0.3"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -44,6 +44,9 @@
   "maintainers": [
     "Josh Ellis (https://github.com/joshuaellis)"
   ],
+  "publishConfig": {
+    "provenance": true
+  },
   "scripts": {
     "build": "tsup",
     "clean": "rm -rf .turbo && rm -rf node_modules && rm -rf dist",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@changesets/changelog-github':
+        specifier: ^0.7.0
+        version: 0.7.0
       '@changesets/cli':
         specifier: 2.27.11
         version: 2.27.11
@@ -836,6 +839,9 @@ packages:
   '@changesets/changelog-git@0.2.1':
     resolution: {integrity: sha512-x/xEleCFLH28c3bQeQIyeZf8lFXyDFVn1SgcBiR2Tw/r4IAWlk1fzxCEZ6NxQAjF2Nwtczoen3OA2qR+UawQ8Q==}
 
+  '@changesets/changelog-github@0.7.0':
+    resolution: {integrity: sha512-rBsbRvc4TVn+FvFnOVM3LxlFJfTXXCp8gfVJ+0BubxWNSVnLuAzowi5j+IEraLLP52w8AAs9QfKbPS3MMiXQJA==}
+
   '@changesets/cli@2.27.11':
     resolution: {integrity: sha512-1QislpE+nvJgSZZo9+Lj3Lno5pKBgN46dAV8IVxKJy9wX8AOrs9nn5pYVZuDpoxWJJCALmbfOsHkyxujgetQSg==}
     hasBin: true
@@ -848,6 +854,9 @@ packages:
 
   '@changesets/get-dependents-graph@2.1.4':
     resolution: {integrity: sha512-ZsS00x6WvmHq3sQv8oCMwL0f/z3wbXCVuSVTJwCnnmbC/iBdNJGFx1EcbMG4PC6sXRyH69liM4A2WKXzn/kRPg==}
+
+  '@changesets/get-github-info@0.8.0':
+    resolution: {integrity: sha512-cRnC+xdF0JIik7coko3iUP9qbnfi1iJQ3sAa6dE+Tx3+ET8bjFEm63PA4WEohgjYcmsOikPHWzPsMWWiZmntOQ==}
 
   '@changesets/get-release-plan@4.0.16':
     resolution: {integrity: sha512-2K5Om6CrMPm45rtvckfzWo7e9jOVCKLCnXia5eUPaURH7/LWzri7pK1TycdzAuAtehLkW7VPbWLCSExTHmiI6g==}
@@ -3731,6 +3740,9 @@ packages:
     resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
     engines: {node: '>=12'}
 
+  dataloader@1.4.0:
+    resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
+
   debounce@1.2.1:
     resolution: {integrity: sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==}
 
@@ -3842,6 +3854,10 @@ packages:
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
+
+  dotenv@8.6.0:
+    resolution: {integrity: sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==}
+    engines: {node: '>=10'}
 
   draco3d@1.5.7:
     resolution: {integrity: sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==}
@@ -5456,6 +5472,15 @@ packages:
 
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -7710,6 +7735,14 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
+  '@changesets/changelog-github@0.7.0':
+    dependencies:
+      '@changesets/get-github-info': 0.8.0
+      '@changesets/types': 6.1.0
+      dotenv: 8.6.0
+    transitivePeerDependencies:
+      - encoding
+
   '@changesets/cli@2.27.11':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
@@ -7762,6 +7795,13 @@ snapshots:
       '@manypkg/get-packages': 1.1.3
       picocolors: 1.1.1
       semver: 7.8.0
+
+  '@changesets/get-github-info@0.8.0':
+    dependencies:
+      dataloader: 1.4.0
+      node-fetch: 2.7.0
+    transitivePeerDependencies:
+      - encoding
 
   '@changesets/get-release-plan@4.0.16':
     dependencies:
@@ -10756,6 +10796,8 @@ snapshots:
       whatwg-url: 11.0.0
     optional: true
 
+  dataloader@1.4.0: {}
+
   debounce@1.2.1: {}
 
   debug@2.6.9:
@@ -10840,6 +10882,8 @@ snapshots:
       is-obj: 2.0.0
 
   dotenv@16.6.1: {}
+
+  dotenv@8.6.0: {}
 
   draco3d@1.5.7: {}
 
@@ -13164,6 +13208,10 @@ snapshots:
 
   node-addon-api@7.1.1:
     optional: true
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
 
   node-int64@0.4.0: {}
 

--- a/scripts/version-and-publish.sh
+++ b/scripts/version-and-publish.sh
@@ -22,6 +22,11 @@ fi
 # publish packages
 ./node_modules/.bin/changeset version --snapshot "$version"
 
+# Attach SLSA provenance to every tarball npm publishes (changeset publish
+# shells out to `npm publish` per package). Requires `id-token: write` on the
+# workflow job.
+export NPM_CONFIG_PROVENANCE=true
+
 if [[ "$withTag" == "true" ]]; then
   ./node_modules/.bin/changeset publish --snapshot --tag "$distTag"
 else

--- a/targets/konva/package.json
+++ b/targets/konva/package.json
@@ -43,6 +43,9 @@
   "maintainers": [
     "Josh Ellis (https://github.com/joshuaellis)"
   ],
+  "publishConfig": {
+    "provenance": true
+  },
   "dependencies": {
     "@react-spring/animated": "~10.0.3",
     "@react-spring/core": "~10.0.3",

--- a/targets/native/package.json
+++ b/targets/native/package.json
@@ -37,6 +37,9 @@
   "maintainers": [
     "Josh Ellis (https://github.com/joshuaellis)"
   ],
+  "publishConfig": {
+    "provenance": true
+  },
   "dependencies": {
     "@react-spring/animated": "~10.0.3",
     "@react-spring/core": "~10.0.3",

--- a/targets/three/package.json
+++ b/targets/three/package.json
@@ -43,6 +43,9 @@
   "maintainers": [
     "Josh Ellis (https://github.com/joshuaellis)"
   ],
+  "publishConfig": {
+    "provenance": true
+  },
   "dependencies": {
     "@react-spring/animated": "~10.0.3",
     "@react-spring/core": "~10.0.3",

--- a/targets/web/package.json
+++ b/targets/web/package.json
@@ -43,6 +43,9 @@
   "maintainers": [
     "Josh Ellis (https://github.com/joshuaellis)"
   ],
+  "publishConfig": {
+    "provenance": true
+  },
   "dependencies": {
     "@react-spring/animated": "~10.0.3",
     "@react-spring/core": "~10.0.3",

--- a/targets/zdog/package.json
+++ b/targets/zdog/package.json
@@ -43,6 +43,9 @@
   "maintainers": [
     "Josh Ellis (https://github.com/joshuaellis)"
   ],
+  "publishConfig": {
+    "provenance": true
+  },
   "dependencies": {
     "@react-spring/animated": "~10.0.3",
     "@react-spring/core": "~10.0.3",


### PR DESCRIPTION
### Summary

Introduces a bot-maintained "Version Packages" PR for `next` and migrates the publish path to npm Trusted Publishing so every published tarball carries a verifiable SLSA provenance attestation.

### What the new workflow does

- Push to `next` **with** unconsumed changesets → opens/updates a `chore: version packages` PR with the version bumps. Nothing publishes.
- Push to `next` **without** unconsumed changesets (i.e. the version PR was just merged) → runs `pnpm changeset publish`, which publishes only packages whose `package.json` version is newer than what's on npm.

Provenance is auto-attached because the job runs with `id-token: write` and the npm CLI ≥ 11.5.1 detects the OIDC environment. After publish, run `npm audit signatures` on a consumer machine to verify, or look for the green "Built and signed on GitHub Actions" badge on each npm package page.

### Manual setup already completed on npmjs.com

Trusted Publisher → GitHub Actions added for all 12 publishable packages (`react-spring`, `@react-spring/{animated,core,parallax,rafz,shared,types,konva,native,three,web,zdog}`) pointing at `pmndrs/react-spring` → `release.yml`.

### Other corrections folded in

- `.changeset/config.json` `baseBranch` was still `main` despite the active line being `next` — fixed.
- `changelog` switched on (`@changesets/changelog-github`) so release PR bodies link each entry to its source PR.
- Existing `nightly.yml` / `experimental.yml` now also attach provenance to their snapshot publishes via `id-token: write` + `NPM_CONFIG_PROVENANCE=true` in `scripts/version-and-publish.sh`. They continue to use `NPM_TOKEN` for now; migrating those flows to Trusted Publishing is a follow-up.