### PR TITLE
fix(core): phase-sync useTrail children on loop iterations

### DIFF
--- a/.changeset/loop-trail-phase-sync.md
+++ b/.changeset/loop-trail-phase-sync.md
@@ -1,0 +1,5 @@
+---
+'@react-spring/core': patch
+---
+
+fix(useTrail): with `loop: true`, deeper springs trap in a mid-range oscillation instead of sweeping the full from→to distance each cycle. The trail chains children via `to: parent.springs`, so every parent change resets the child's animation progress; under looping, the head snap-resets each cycle but children only chase fluidly. An internal `Controller.onLoopReset` subscription now fires synchronously when the head recurses into the next loop iteration, and every non-head child snaps back to `from` in phase. The fluid-chain contract is preserved. Fixes #1063.

--- a/packages/core/src/Controller.ts
+++ b/packages/core/src/Controller.ts
@@ -88,6 +88,13 @@ export class Controller<State extends Lookup = Lookup> {
     timeouts: new Set(),
   }
 
+  /**
+   * Listeners notified synchronously each time `flushUpdate` recurses into
+   * the next loop iteration. Used by `useTrail` to keep chained children
+   * phase-aligned with the head controller's loop restarts.
+   */
+  protected _onLoopReset?: Set<() => void>
+
   /** The event queues that are flushed once per frame maximum */
   protected _events = {
     onStart: new Map<
@@ -238,6 +245,20 @@ export class Controller<State extends Lookup = Lookup> {
   /** Call a function once per spring value */
   each(iterator: (spring: SpringValue, key: string) => void) {
     eachProp(this.springs, iterator as any)
+  }
+
+  /**
+   * Subscribe to loop iteration restarts on this controller. Returns an
+   * unsubscribe function. Listeners fire synchronously inside `flushUpdate`
+   * just before the next iteration is dispatched.
+   * @internal
+   */
+  onLoopReset(fn: () => void): () => void {
+    const set = (this._onLoopReset ??= new Set())
+    set.add(fn)
+    return () => {
+      set.delete(fn)
+    }
   }
 
   /** @internal Called at the end of every animation frame */
@@ -431,6 +452,10 @@ export async function flushUpdate(
   if (loop && result.finished && !(isLoop && result.noop)) {
     const nextProps = createLoopUpdate(props, loop, to)
     if (nextProps) {
+      // Notify subscribers that the next loop iteration is about to start
+      // so dependent controllers (e.g. useTrail children) can phase-sync
+      // before this controller's springs snap back to their `from` value.
+      ctrl['_onLoopReset']?.forEach(fn => fn())
       prepareKeys(ctrl, [nextProps])
       return flushUpdate(ctrl, nextProps, true)
     }

--- a/packages/core/src/hooks/useTrail.test.tsx
+++ b/packages/core/src/hooks/useTrail.test.tsx
@@ -54,6 +54,45 @@ describe('useTrail', () => {
       it.todo('has each spring follow the spring before it')
     })
   })
+
+  // Issue #1063: with `loop: true`, every parent change re-enters the child's
+  // `_start` → `AnimatedValue.reset()`, zeroing its progress each frame. Each
+  // child acts as a low-pass filter on its parent, so under looping, deeper
+  // children trap in a narrowing band near the mid-range and never sweep the
+  // full from→to distance. The fix subscribes every non-head child to the
+  // head's loop restarts so they snap back to `from` in phase.
+  describe('with the "loop" prop (issue #1063)', () => {
+    it('phase-syncs every spring on each loop iteration', async () => {
+      const length = 4
+      update(length, { from: { x: 0 }, to: { x: 100 }, loop: true })
+
+      expect(springs.length).toBe(length)
+
+      // Warm up past the first cycle so steady-state behaviour dominates the
+      // sample. Default physics (tension 170, friction 26) settles in ~80
+      // frames per head loop; 300 frames covers ~3 head cycles.
+      await global.advance(300)
+
+      // Drain warm-up frames so the next window measures only steady state.
+      springs.forEach(s => global.getFrames(s.x))
+
+      // Sample long enough to cover multiple head loops.
+      await global.advance(300)
+
+      springs.forEach((s, i) => {
+        const frames = global.getFrames(s.x)
+        expect(
+          frames.length,
+          `spring[${i}] produced no frames in the sample window`
+        ).toBeGreaterThan(0)
+        const min = Math.min(...(frames as number[]))
+        // Every spring should return close to `from` (0) on every iteration.
+        // Without the phase-sync, deeper children trap above ~50 and never
+        // approach 0 (e.g. spring[3] sits ~70 in steady state).
+        expect(min, `spring[${i}] min over window: ${min}`).toBeLessThan(20)
+      })
+    })
+  })
 })
 
 function createUpdater(

--- a/packages/core/src/hooks/useTrail.ts
+++ b/packages/core/src/hooks/useTrail.ts
@@ -121,11 +121,21 @@ export function useTrail(
   )
 
   useIsomorphicLayoutEffect(() => {
+    const ctrls = result[1].current
+    // The head is the only controller whose `flushUpdate` reaches the loop
+    // recursion: it animates to a static `to`, so its result finishes. Every
+    // other ctrl chains via `to: parent.springs` (fluid), which never settles
+    // and so never triggers `createLoopUpdate`. Subscribing children to their
+    // immediate parent would cascade exactly one level; subscribing every
+    // non-head child directly to the head keeps the whole trail in phase.
+    const head = ctrls[reverse ? ctrls.length - 1 : 0]
+    const unsubscribers: Array<() => void> = []
+
     /**
      * Run through the ref passed by the `useSprings` hook.
      */
-    each(result[1].current, (ctrl, i) => {
-      const parent = result[1].current[i + (reverse ? 1 : -1)]
+    each(ctrls, (ctrl, i) => {
+      const parent = ctrls[i + (reverse ? 1 : -1)]
 
       /**
        * If there's a passed ref then we replace the ctrl ref with it
@@ -141,16 +151,28 @@ export function useTrail(
         if (parent) {
           ctrl.update({ to: parent.springs })
         }
-
-        return
-      }
-
-      if (parent) {
+      } else if (parent) {
         ctrl.start({ to: parent.springs })
       } else {
         ctrl.start()
       }
+
+      // Phase-sync non-head children to the head's loop iterations. Without
+      // this, the parent snap-resets each cycle and every child filters the
+      // ramp asymmetrically, trapping deeper children in a narrow mid-range
+      // oscillation instead of completing the full sweep. See issue #1063.
+      if (ctrl !== head) {
+        unsubscribers.push(
+          head.onLoopReset(() => {
+            ctrl.start({ reset: true })
+          })
+        )
+      }
     })
+
+    return () => {
+      each(unsubscribers, unsubscribe => unsubscribe())
+    }
   }, deps)
 
   if (propsFn || arguments.length == 3) {


### PR DESCRIPTION
Closes #1063.

### Problem

`useTrail` chains each child via `to: parent.springs`, so every parent change re-enters the child's `_start` → `AnimatedValue.reset()`, zeroing its progress each frame. With `loop: true`, the head snap-resets to `from` each cycle but children only chase fluidly — they trap in a narrowing band near the mid-range and never sweep the full from→to distance. Deeper children trap further from the target.

### Fix

Add an internal `Controller.onLoopReset` subscription that fires synchronously inside `flushUpdate` just before `createLoopUpdate` recurses. `useTrail` subscribes every non-head child directly to the **head** controller — the only controller whose `flushUpdate` reaches the loop tail (children's `to` is fluid, so their updates never finish). Chaining via immediate parents would cascade only one level; subscribing to the head keeps the whole trail in phase.

On loop restart, each child snaps back to `from` via `ctrl.start({ reset: true })`, then resumes chasing the parent through the fluid chain. The fluid-chain contract (load-bearing for the `goo-blobs` mouse-follow demo) is preserved — the existing `'has each spring follow the spring before it'` test still passes.

### Out of scope

`loop` triggers when the head finishes, so deeper springs can still be cut off before reaching `to` under short-duration configs. That's a separate API design choice worth a follow-up.