### PR TITLE
chore(renovate): group deps by ecosystem and isolate majors

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,136 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base",
-    "group:allNonMajor",
+    "config:recommended",
     "schedule:monthly",
     ":maintainLockFilesMonthly",
     ":disablePeerDependencies",
     ":labels(dependencies,kind: chore)"
   ],
   "rangeStrategy": "bump",
-  "postUpdateOptions": ["yarnDedupeHighest"],
-  "rebaseWhen": "conflicted"
+  "rebaseWhen": "conflicted",
+  "separateMajorMinor": true,
+  "separateMultipleMajor": true,
+  "packageRules": [
+    {
+      "groupName": "react",
+      "matchPackageNames": [
+        "react",
+        "react-dom",
+        "@types/react",
+        "@types/react-dom"
+      ]
+    },
+    {
+      "groupName": "react-native",
+      "matchPackageNames": ["react-native"]
+    },
+    {
+      "groupName": "react-three",
+      "matchPackageNames": [
+        "@react-three/fiber",
+        "@react-three/drei",
+        "three",
+        "@types/three",
+        "three-stdlib"
+      ]
+    },
+    {
+      "groupName": "konva",
+      "matchPackageNames": ["konva", "react-konva"]
+    },
+    {
+      "groupName": "zdog",
+      "matchPackageNames": ["zdog", "react-zdog"]
+    },
+    {
+      "groupName": "remix",
+      "matchPackageNames": ["@remix-run/**", "@vercel/remix"]
+    },
+    {
+      "groupName": "radix-ui",
+      "matchPackageNames": ["@radix-ui/**"]
+    },
+    {
+      "groupName": "vanilla-extract",
+      "matchPackageNames": ["@vanilla-extract/**"]
+    },
+    {
+      "groupName": "mdx",
+      "matchPackageNames": ["@mdx-js/**"]
+    },
+    {
+      "groupName": "remark-rehype",
+      "matchPackageNames": [
+        "unified",
+        "refractor",
+        "/^remark-/",
+        "/^rehype-/",
+        "/^hast-util-/",
+        "/^unist-util-/"
+      ]
+    },
+    {
+      "groupName": "docsearch",
+      "matchPackageNames": ["@docsearch/**"]
+    },
+    {
+      "groupName": "supabase",
+      "matchPackageNames": ["@supabase/**"]
+    },
+    {
+      "groupName": "vercel",
+      "matchPackageNames": ["@vercel/analytics"]
+    },
+    {
+      "groupName": "changesets",
+      "matchPackageNames": ["@changesets/**"]
+    },
+    {
+      "groupName": "commitlint",
+      "matchPackageNames": ["@commitlint/**"]
+    },
+    {
+      "groupName": "vitest",
+      "matchPackageNames": [
+        "vitest",
+        "@vitest/**",
+        "vitest-browser-react",
+        "playwright"
+      ]
+    },
+    {
+      "groupName": "oxc",
+      "matchPackageNames": ["oxlint", "oxfmt"]
+    },
+    {
+      "groupName": "build-tooling",
+      "matchPackageNames": ["tsup", "turbo", "@swc/core"]
+    },
+    {
+      "groupName": "vite",
+      "matchPackageNames": ["vite", "@vitejs/**", "vite-tsconfig-paths"]
+    },
+    {
+      "groupName": "typescript",
+      "matchPackageNames": ["typescript"]
+    },
+    {
+      "groupName": "lodash",
+      "matchPackageNames": [
+        "lodash-move",
+        "/^lodash\\./",
+        "/^@types\\/lodash\\./"
+      ]
+    },
+    {
+      "groupName": "use-gesture",
+      "matchPackageNames": ["@use-gesture/react", "react-use-gesture"]
+    },
+    {
+      "matchUpdateTypes": ["major"],
+      "groupName": null,
+      "addLabels": ["major-update"]
+    }
+  ]
 }


### PR DESCRIPTION
### Summary

Replaces the blanket `group:allNonMajor` preset with explicit per-ecosystem groups so updates land in reviewable, related batches instead of a single all-or-nothing PR. Every grouped dependency is listed by name (or a tight pattern) so the scope of each Renovate PR is obvious from the config alone.

### Notable changes

- Drops `group:allNonMajor` — the source of "every non-major in one PR" behaviour
- Bumps deprecated `config:base` to `config:recommended`
- Removes `yarnDedupeHighest` (this repo is pnpm)
- Adds `packageRules` for: react core, react-native, react-three, konva, zdog, remix, radix-ui, vanilla-extract, mdx, remark/rehype/unified, docsearch, supabase, vercel, changesets, commitlint, vitest + playwright, oxc, build tooling (tsup/turbo/swc), vite, typescript, lodash micro-packages, use-gesture
- Final rule overrides any group for `major` updates so every breaking bump gets its own PR with a `major-update` label