### PR TITLE
chore(ci): refresh typescript test matrix to 5.0, 5.4, 5.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -141,7 +141,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ts: ['5.0', '5.1', '5.2']
+        ts: ['5.0', '5.4', '5.7']
 
     steps:
       - name: Checkout repo


### PR DESCRIPTION
### Summary

Refreshes the stale `test-types` matrix in `tests.yml`. Drops `5.1` and `5.2`, adds `5.4` (mid-band) and `5.7` (the version the repo actually develops against — `package.json` pins `typescript@5.7.2`). Floor stays at `5.0`.

### Trialled but dropped

`5.9` and `6.0` were exercised locally and both fail `pnpm test:ts`. Per the agreed approach for coverage-expansion PRs, they're dropped here and tracked as follow-ups:

- #2441 — TypeScript 5.9: five source-level inference errors in `packages/core/src/helpers.ts` and `packages/shared/src/helpers.ts`.
- #2442 — TypeScript 6.0: two `tsconfig.json` deprecation errors (`downlevelIteration`, `baseUrl`).

### Decisions

- No declared floor in `peerDependencies` / `engines` / README — matrix remains the only source of truth.
- Minor-only pins (e.g. `5.7` not `5.7.3`); pnpm resolves the latest patch at install time.
- `.github/publish-ci/*` examples keep their independent `typescript@4.9.5` pin (out of scope).