### PR TITLE
fix(core): stop superseded loop chains on re-render

### DIFF
--- a/.changeset/stop-superseded-loop-chains.md
+++ b/.changeset/stop-superseded-loop-chains.md
@@ -1,0 +1,5 @@
+---
+'@react-spring/core': patch
+---
+
+Stop looping when a re-render flips `loop` to a falsy value. Previously a declarative update like `useSpring({ to, loop })` would keep looping even after `loop` toggled to `false`, because the in-flight loop chain captured its own `loop` value and kept scheduling iterations in parallel with the new update. The Controller now tags each loop chain with a generation token and exits when a newer external update has superseded it. Closes #1193.

--- a/packages/core/src/Controller.test.ts
+++ b/packages/core/src/Controller.test.ts
@@ -500,6 +500,37 @@ describe('Controller', () => {
       })
     })
 
+    // Regression test for https://github.com/pmndrs/react-spring/issues/1193
+    describe('when changed on a later update', () => {
+      it('stops looping when toggled from true to false', async () => {
+        const ctrl = new Controller<{ t: number }>({ t: 0 })
+        const { t } = ctrl.springs
+
+        ctrl.start({
+          from: { t: 0 },
+          to: { t: 1 },
+          loop: true,
+          config: { duration: 3000 / 60 },
+        })
+
+        await global.advanceUntilValue(t, 1)
+        expect(t.idle).toBeFalsy()
+
+        // Re-render with the same goal but `loop` flipped to false.
+        // The captured `loop: true` in the prior chain would otherwise
+        // keep scheduling iterations even though the user wants to stop.
+        ctrl.start({
+          from: { t: 0 },
+          to: { t: 1 },
+          loop: false,
+          config: { duration: 3000 / 60 },
+        })
+
+        await global.advanceUntilIdle()
+        expect(t.idle).toBeTruthy()
+      })
+    })
+
     describe('when "finish" is called while paused', () => {
       async function getPausedLoop() {
         const ctrl = new Controller<{ t: number }>({

--- a/packages/core/src/Controller.ts
+++ b/packages/core/src/Controller.ts
@@ -69,6 +69,16 @@ export class Controller<State extends Lookup = Lookup> {
   /** The counter for tracking `scheduleProps` calls */
   protected _lastAsyncId = 0
 
+  /**
+   * Token identifying the in-flight loop chain. Bumped on every top-level
+   * `flushUpdate` so a subsequent loop iteration can detect that a newer
+   * external update has superseded it, and exit instead of dispatching
+   * another iteration. Without this, a `loop: true → loop: false` (or any
+   * non-loop) update from a re-render would race against the captured
+   * `loop` of the prior chain, which keeps recursing. See issue #1193.
+   */
+  protected _lastLoopId = 0
+
   /** The values currently being animated */
   protected _active = new Set<FrameValue>()
 
@@ -347,6 +357,21 @@ export async function flushUpdate(
     props.loop = false
   }
 
+  // Top-level external calls bump the loop generation so an earlier loop
+  // chain can notice it has been superseded — but only when this update
+  // could express a different loop intent. Updates from `runAsync`'s
+  // internal `animate` carry a `parentId`, and pure lifecycle updates
+  // (`ctrl.pause()` / `ctrl.resume()`) don't mention `loop`; in both
+  // cases bumping would kill the very loop chain that scheduled them.
+  // Recursive iterations (isLoop) inherit the id from the props.
+  const propsAny = props as any
+  const isExternalLoopIntent = !isLoop && !propsAny.parentId && 'loop' in props
+  const loopId: number = isExternalLoopIntent
+    ? ++ctrl['_lastLoopId']
+    : isLoop
+      ? propsAny.loopId
+      : ctrl['_lastLoopId']
+
   // Treat false like null, which gets ignored.
   if (to === false) props.to = null
   if (from === false) props.from = null
@@ -449,9 +474,19 @@ export async function flushUpdate(
   }
 
   const result = getCombinedResult<any>(ctrl, await Promise.all(promises))
-  if (loop && result.finished && !(isLoop && result.noop)) {
+  if (
+    loop &&
+    result.finished &&
+    !(isLoop && result.noop) &&
+    // A newer top-level update would have bumped `_lastLoopId`; if our
+    // captured id no longer matches, the user's loop intent has changed
+    // (or restarted under a fresh chain) so this iteration must not
+    // dispatch another one.
+    loopId === ctrl['_lastLoopId']
+  ) {
     const nextProps = createLoopUpdate(props, loop, to)
     if (nextProps) {
+      ;(nextProps as any).loopId = loopId
       // Notify subscribers that the next loop iteration is about to start
       // so dependent controllers (e.g. useTrail children) can phase-sync
       // before this controller's springs snap back to their `from` value.


### PR DESCRIPTION
Closes #1193.

### Summary

Toggling `loop` from truthy to falsy on a re-render did not actually stop the animation. The in-flight `flushUpdate` chain captured its own `loop` value in a closure, so the captured `true` kept the recursion alive even when the new top-level update arrived with `loop: false`. Both chains then ran in parallel — the old one scheduled iterations indefinitely, the new one was a no-op.

### Fix

`Controller` now carries a `_lastLoopId` generation token. A top-level external update bumps the token only when it could express a different loop intent (i.e. it mentions `loop` and is not an internal sub-step from `runAsync`'s `animate`, which carries `parentId`, nor a `pause`/`resume` lifecycle call). Each loop chain captures its token; before recursing into the next iteration it checks the token still matches `_lastLoopId` and otherwise exits.

This is the minimal scoping required to avoid regressions in the three existing loop tests that rely on `runAsync` sub-steps and pause/resume cycles preserving the chain.

A regression test mirroring the reported shape (`loop: true → loop: false` via a second `ctrl.start`) is added in `Controller.test.ts`.