### PR TITLE
chore: replace deprecated @vitejs/plugin-react-refresh

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -16,7 +16,7 @@
     "@react-three/fiber": "~9.6.1",
     "@stitches/react": "1.2.8",
     "@use-gesture/react": "10.3.1",
-    "@vitejs/plugin-react-refresh": "1.3.6",
+    "@vitejs/plugin-react": "4.7.0",
     "easing-coordinates": "2.0.2",
     "leva": "0.10.1",
     "lodash-move": "1.1.1",

--- a/demo/vite.config.ts
+++ b/demo/vite.config.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import { defineConfig } from 'vite'
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   resolve: {
@@ -13,5 +13,5 @@ export default defineConfig({
   server: {
     port: 4000,
   },
-  plugins: [reactRefresh()],
+  plugins: [react()],
 })

--- a/packages/parallax/package.json
+++ b/packages/parallax/package.json
@@ -58,7 +58,7 @@
     "@react-spring/web": "workspace:~"
   },
   "devDependencies": {
-    "@vitejs/plugin-react-refresh": "1.3.6",
+    "@vitejs/plugin-react": "4.7.0",
     "wouter": "3.10.0"
   },
   "peerDependencies": {

--- a/packages/parallax/test/vite.config.ts
+++ b/packages/parallax/test/vite.config.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import { defineConfig } from 'vite'
-import reactRefresh from '@vitejs/plugin-react-refresh'
+import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   resolve: {
@@ -14,5 +14,5 @@ export default defineConfig({
   server: {
     port: 3000,
   },
-  plugins: [reactRefresh()],
+  plugins: [react()],
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,9 +131,9 @@ importers:
       '@use-gesture/react':
         specifier: 10.3.1
         version: 10.3.1(react@19.2.6)
-      '@vitejs/plugin-react-refresh':
-        specifier: 1.3.6
-        version: 1.3.6
+      '@vitejs/plugin-react':
+        specifier: 4.7.0
+        version: 4.7.0(vite@6.0.7(@types/node@25.9.1)(jiti@2.6.1)(sass@1.100.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
       easing-coordinates:
         specifier: 2.0.2
         version: 2.0.2
@@ -410,9 +410,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
         version: 19.2.6(react@19.2.6)
     devDependencies:
-      '@vitejs/plugin-react-refresh':
-        specifier: 1.3.6
-        version: 1.3.6
+      '@vitejs/plugin-react':
+        specifier: 4.7.0
+        version: 4.7.0(vite@6.0.7(@types/node@25.9.1)(jiti@2.6.1)(sass@1.100.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))
       wouter:
         specifier: 3.10.0
         version: 3.10.0(react@19.2.6)
@@ -2579,9 +2579,8 @@ packages:
       typescript:
         optional: true
 
-  '@rollup/pluginutils@4.2.1':
-    resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
-    engines: {node: '>= 8.0.0'}
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -2866,6 +2865,18 @@ packages:
   '@tweenjs/tween.js@23.1.3':
     resolution: {integrity: sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==}
 
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -3068,10 +3079,11 @@ packages:
   '@vercel/static-config@3.3.0':
     resolution: {integrity: sha512-GpS3tPwUeDJCkrKbMNtS2XLRFgfxTlN7YNUL+Bo23+fGolrDw6Oq79R3yvxTYgqRaJMGSEqC7iMw6mj6I5loxg==}
 
-  '@vitejs/plugin-react-refresh@1.3.6':
-    resolution: {integrity: sha512-iNR/UqhUOmFFxiezt0em9CgmiJBdWR+5jGxB2FihaoJfqGt76kiwaKoVOJVU5NYcDWMdN06LbyN2VIGIoYdsEA==}
-    engines: {node: '>=12.0.0'}
-    deprecated: This package has been deprecated in favor of @vitejs/plugin-react
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
   '@vitest/browser-playwright@4.1.7':
     resolution: {integrity: sha512-OlTlJej7YN6VwV7zJJoNeaCsctF+JXpzpZ4oBHUbrQFfIq+0KW2f07rprCLh9N/zRIZ0v4Mchn1QDDmWMUhPKw==}
@@ -5256,12 +5268,12 @@ packages:
     peerDependencies:
       react: ^19.2.0
 
-  react-refresh@0.10.0:
-    resolution: {integrity: sha512-PgidR3wST3dDYKr6b4pJoqQFpPGNKDSCDx4cZoshjXipw3LzO7mG1My2pwEzz2JVkF+inx3xRpDeQLFQGH/hsQ==}
-    engines: {node: '>=0.10.0'}
-
   react-refresh@0.14.2:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
+    engines: {node: '>=0.10.0'}
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
   react-remove-scroll-bar@2.3.8:
@@ -8369,10 +8381,7 @@ snapshots:
       typescript: 5.7.2
     optional: true
 
-  '@rollup/pluginutils@4.2.1':
-    dependencies:
-      estree-walker: 2.0.2
-      picomatch: 2.3.2
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.4)':
     dependencies:
@@ -8562,6 +8571,27 @@ snapshots:
     optional: true
 
   '@tweenjs/tween.js@23.1.3': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
 
   '@types/chai@5.2.3':
     dependencies:
@@ -8804,13 +8834,15 @@ snapshots:
       json-schema-to-ts: 1.6.4
       ts-morph: 12.0.0
 
-  '@vitejs/plugin-react-refresh@1.3.6':
+  '@vitejs/plugin-react@4.7.0(vite@6.0.7(@types/node@25.9.1)(jiti@2.6.1)(sass@1.100.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
       '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
-      '@rollup/pluginutils': 4.2.1
-      react-refresh: 0.10.0
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.0.7(@types/node@25.9.1)(jiti@2.6.1)(sass@1.100.0)(terser@5.47.1)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -11567,9 +11599,9 @@ snapshots:
       react: 19.2.6
       scheduler: 0.27.0
 
-  react-refresh@0.10.0: {}
-
   react-refresh@0.14.2: {}
+
+  react-refresh@0.17.0: {}
 
   react-remove-scroll-bar@2.3.8(@types/react@19.2.15)(react@19.2.6):
     dependencies:


### PR DESCRIPTION
### Summary

Replace the deprecated [@vitejs/plugin-react-refresh](https://github.com/vitejs/vite-plugin-react-refresh) (last published 2021) with the modern [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react). Flagged by Renovate in #2076 with no automated replacement PR available.

Two consumers in this repo, both dev/test-only — nothing in the published library output:

- \`demo/vite.config.ts\` + \`demo/package.json\`
- \`packages/parallax/test/vite.config.ts\` + \`packages/parallax/package.json\` (devDep)

Pinned to \`4.7.0\` rather than the latest \`6.x\` because \`@vitejs/plugin-react@6\` requires \`vite@^8.0.0\` and the workspace is still on \`vite@6\`. The vite v8 bump is its own Renovate PR (#2495) — once that lands, this can be majored up separately.

### Why now

Removes a deprecated dep, unblocks part of the Renovate dependency dashboard.