### PR TITLE
chore(demo): replace deprecated react-use-gesture with @use-gesture/react

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -26,7 +26,6 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-feather": "2.0.10",
-    "react-use-gesture": "9.1.3",
     "react-use-measure": "2.1.7",
     "react95": "4.0.0",
     "sass": "1.100.0",

--- a/demo/src/sandboxes/card/package.json
+++ b/demo/src/sandboxes/card/package.json
@@ -12,10 +12,10 @@
   ],
   "dependencies": {
     "@react-spring/web": "*",
+    "@use-gesture/react": "10.3.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "react-scripts": "5.0.1",
-    "react-use-gesture": "9.1.3"
+    "react-scripts": "5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/demo/src/sandboxes/card/src/App.tsx
+++ b/demo/src/sandboxes/card/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useEffect } from 'react'
 import { useSpring, animated, to } from '@react-spring/web'
-import { useGesture } from 'react-use-gesture'
+import { useGesture } from '@use-gesture/react'
 import imgs from './data'
 
 import styles from './styles.module.css'
@@ -60,7 +60,7 @@ export default function App() {
         wheelApi.set({ wheelY: y })
       },
     },
-    { domTarget, eventOptions: { passive: false } }
+    { target: domTarget, eventOptions: { passive: false } }
   )
   return (
     <div className={styles.container}>

--- a/demo/src/sandboxes/cards-stack/package.json
+++ b/demo/src/sandboxes/cards-stack/package.json
@@ -12,10 +12,10 @@
   ],
   "dependencies": {
     "@react-spring/web": "*",
+    "@use-gesture/react": "10.3.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "react-scripts": "5.0.1",
-    "react-use-gesture": "9.1.3"
+    "react-scripts": "5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/demo/src/sandboxes/cards-stack/src/App.tsx
+++ b/demo/src/sandboxes/cards-stack/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { useSprings, animated, to as interpolate } from '@react-spring/web'
-import { useDrag } from 'react-use-gesture'
+import { useDrag } from '@use-gesture/react'
 
 import styles from './styles.module.css'
 

--- a/demo/src/sandboxes/draggable-list/package.json
+++ b/demo/src/sandboxes/draggable-list/package.json
@@ -12,12 +12,12 @@
   "main": "src/index.tsx",
   "dependencies": {
     "@react-spring/web": "*",
+    "@use-gesture/react": "10.3.1",
     "lodash.clamp": "4.0.3",
     "lodash-move": "1.1.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "react-scripts": "5.0.1",
-    "react-use-gesture": "9.1.3"
+    "react-scripts": "5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/demo/src/sandboxes/draggable-list/src/App.tsx
+++ b/demo/src/sandboxes/draggable-list/src/App.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import { useSprings, animated } from '@react-spring/web'
-import { useDrag } from 'react-use-gesture'
+import { useDrag } from '@use-gesture/react'
 import clamp from 'lodash.clamp'
 import swap from 'lodash-move'
 

--- a/demo/src/sandboxes/list-reordering/package.json
+++ b/demo/src/sandboxes/list-reordering/package.json
@@ -12,8 +12,7 @@
     "lodash.shuffle": "4.2.0",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "react-scripts": "5.0.1",
-    "react-use-gesture": "9.1.3"
+    "react-scripts": "5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/demo/src/sandboxes/masonry/package.json
+++ b/demo/src/sandboxes/masonry/package.json
@@ -14,7 +14,6 @@
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-scripts": "5.0.1",
-    "react-use-gesture": "9.1.3",
     "react-use-measure": "2.1.7"
   },
   "scripts": {

--- a/demo/src/sandboxes/rocket-decay/package.json
+++ b/demo/src/sandboxes/rocket-decay/package.json
@@ -14,10 +14,10 @@
   "main": "src/index.js",
   "dependencies": {
     "@react-spring/web": "*",
+    "@use-gesture/react": "10.3.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-scripts": "5.0.1",
-    "react-use-gesture": "9.1.3",
     "vec-la": "1.5.0"
   },
   "devDependencies": {

--- a/demo/src/sandboxes/rocket-decay/src/App.tsx
+++ b/demo/src/sandboxes/rocket-decay/src/App.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { useSpring, to, animated, config } from '@react-spring/web'
 import { scale, dist } from 'vec-la'
-import { useDrag } from 'react-use-gesture'
+import { useDrag } from '@use-gesture/react'
 
 import styles from './styles.module.css'
 

--- a/demo/src/sandboxes/slide/package.json
+++ b/demo/src/sandboxes/slide/package.json
@@ -11,10 +11,10 @@
   "main": "src/index.tsx",
   "dependencies": {
     "@react-spring/web": "*",
+    "@use-gesture/react": "10.3.1",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
-    "react-scripts": "5.0.1",
-    "react-use-gesture": "9.1.3"
+    "react-scripts": "5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/demo/src/sandboxes/slide/src/App.tsx
+++ b/demo/src/sandboxes/slide/src/App.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react'
 import { useSpring, animated } from '@react-spring/web'
-import { useDrag } from 'react-use-gesture'
+import { useDrag } from '@use-gesture/react'
 
 import styles from './styles.module.css'
 

--- a/demo/src/sandboxes/viewpager/package.json
+++ b/demo/src/sandboxes/viewpager/package.json
@@ -11,13 +11,13 @@
   "main": "src/index.tsx",
   "dependencies": {
     "@react-spring/web": "*",
+    "@use-gesture/react": "10.3.1",
     "lodash-es": "4.18.1",
     "lodash-move": "1.1.1",
     "lodash.clamp": "4.0.3",
     "react": "^19.2.6",
     "react-dom": "^19.2.6",
     "react-scripts": "5.0.1",
-    "react-use-gesture": "9.1.3",
     "react-use-measure": "2.1.7"
   },
   "scripts": {

--- a/demo/src/sandboxes/viewpager/src/App.tsx
+++ b/demo/src/sandboxes/viewpager/src/App.tsx
@@ -1,7 +1,7 @@
 import React, { useRef } from 'react'
 import { useSprings, animated } from '@react-spring/web'
 import useMeasure from 'react-use-measure'
-import { useDrag } from 'react-use-gesture'
+import { useDrag } from '@use-gesture/react'
 import clamp from 'lodash.clamp'
 
 import styles from './styles.module.css'
@@ -27,8 +27,9 @@ function Viewpager() {
     [width]
   )
   const bind = useDrag(
-    ({ active, movement: [mx], direction: [xDir], distance, cancel }) => {
-      if (active && distance > width / 2) {
+    ({ active, movement: [mx], direction: [xDir], cancel }) => {
+      const dist = Math.abs(mx)
+      if (active && dist > width / 2) {
         index.current = clamp(
           index.current + (xDir > 0 ? -1 : 1),
           0,
@@ -40,7 +41,7 @@ function Viewpager() {
         if (i < index.current - 1 || i > index.current + 1)
           return { display: 'none' }
         const x = (i - index.current) * width + (active ? mx : 0)
-        const scale = active ? 1 - distance / width / 2 : 1
+        const scale = active ? 1 - dist / width / 2 : 1
         return { x, scale, display: 'block' }
       })
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,9 +161,6 @@ importers:
       react-feather:
         specifier: 2.0.10
         version: 2.0.10(react@19.2.6)
-      react-use-gesture:
-        specifier: 9.1.3
-        version: 9.1.3(react@19.2.6)
       react-use-measure:
         specifier: 2.1.7
         version: 2.1.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -5328,12 +5325,6 @@ packages:
     peerDependencies:
       react: '>=16.6.0'
       react-dom: '>=16.6.0'
-
-  react-use-gesture@9.1.3:
-    resolution: {integrity: sha512-CdqA2SmS/fj3kkS2W8ZU8wjTbVBAIwDWaRprX7OKaj7HlGwBasGEFggmk5qNklknqk9zK/h8D355bEJFTpqEMg==}
-    deprecated: This package is no longer maintained. Please use @use-gesture/react instead
-    peerDependencies:
-      react: '>= 16.8.0'
 
   react-use-measure@2.1.7:
     resolution: {integrity: sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==}
@@ -11645,10 +11636,6 @@ snapshots:
       prop-types: 15.8.1
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-
-  react-use-gesture@9.1.3(react@19.2.6):
-    dependencies:
-      react: 19.2.6
 
   react-use-measure@2.1.7(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:


### PR DESCRIPTION
### Summary

Replace the deprecated [react-use-gesture](https://www.npmjs.com/package/react-use-gesture) (v9, last published 2021) with its modern successor [@use-gesture/react](https://use-gesture.netlify.app/) (also pmndrs). Flagged by Renovate in #2076 with no automated replacement PR available.

All usage is confined to demo sandboxes — nothing in the published library output.

### API adjustments for v9 → v10

The handler shape is largely identical, but two demos needed touch-ups:

- **card**: \`useGesture\` config option \`domTarget\` was renamed to \`target\` in v10.
- **viewpager**: \`distance\` changed from a scalar (euclidean magnitude) to \`[dx, dy]\`. Replaced with \`Math.abs(mx)\` since the carousel only tracks x-axis displacement.

\`masonry\` and \`list-reordering\` listed the dep but never imported it — removed alongside the swap.

### Notes

Demo sandboxes aren't covered by CI (no E2E click-through), so the import path / type-check is what's verified here. The runtime behaviour of each sandbox should be manually spot-checked at some point — but since the v9 → v10 handler shape is back-compatible for the simple \`useDrag\` cases used here, no behaviour change is expected.