### PR TITLE
docs: clarify SpringValues typing vs CSSProperties

### DIFF
--- a/docs/app/routes/docs.components.use-transition.mdx
+++ b/docs/app/routes/docs.components.use-transition.mdx
@@ -108,6 +108,7 @@ Where `ConfigObject` is described [above](#reference)
 
 ### TS Glossary
 
+- [`SpringValues`](/docs/typescript#springvalues)
 - [`TransitionState`](/docs/typescript#transitionstate)
 
 ## Examples

--- a/docs/app/routes/docs.concepts.animated-elements.mdx
+++ b/docs/app/routes/docs.concepts.animated-elements.mdx
@@ -96,6 +96,36 @@ const App = () => {
 
 If the component you are wrapping does not pass this element then <strong>nothing will animate</strong>.
 
+## Typing components that receive animated styles
+
+When you wrap a third-party component with `animated()`, the wrapper's `style`
+prop is typed correctly for you. But when you forward `SpringValues` through a
+component you wrote — for example, the styles handed back by a `useTransition`
+render callback — the receiving prop has to be typed as `SpringValues`, not
+`React.CSSProperties`. Each entry is a `SpringValue` instance, not the
+underlying primitive.
+
+```tsx
+import { animated, SpringValues, useTransition } from '@react-spring/web'
+
+const Item = ({ styles }: { styles: SpringValues<{ opacity: number }> }) => (
+  <animated.div style={styles}>Hello</animated.div>
+)
+
+const List = ({ items }: { items: number[] }) => {
+  const transitions = useTransition(items, {
+    from: { opacity: 0 },
+    enter: { opacity: 1 },
+    leave: { opacity: 0 },
+  })
+
+  return transitions(styles => <Item styles={styles} />)
+}
+```
+
+See [`SpringValues`](/docs/typescript#springvalues) for related notes on
+literal-value widening inside `useSpring`.
+
 ## Example: using stitches & radix-ui
 
 ```jsx live=true template=dialog

--- a/docs/app/routes/docs.typescript.mdx
+++ b/docs/app/routes/docs.typescript.mdx
@@ -104,6 +104,34 @@ type MySpringValues = SpringValues<{
 }>
 ```
 
+### Passing animated styles to a child component
+
+`SpringValues` is **not** `React.CSSProperties`. Each entry is a `SpringValue`
+instance, not the underlying primitive — so a prop typed as `CSSProperties` will
+reject them. Type the receiving prop as `SpringValues` instead:
+
+```tsx
+import { animated, SpringValues, useTransition } from '@react-spring/web'
+
+const Item = ({ styles }: { styles: SpringValues<{ opacity: number }> }) => (
+  <animated.div style={styles}>Hello</animated.div>
+)
+```
+
+### Widening literal values
+
+`useSpring` infers each value's type from your config. A ternary like
+`showMenu ? 'all' : 'none'` widens to `string`, which doesn't satisfy a literal
+union such as `CSSProperties['pointerEvents']`. Narrow the value at the call
+site:
+
+```tsx
+const styles = useSpring({
+  opacity: showMenu ? 1 : 0,
+  pointerEvents: showMenu ? ('all' as const) : ('none' as const),
+})
+```
+
 ## TransitionState
 
 `TransitionState` is the internal state attached to a particular `Item`


### PR DESCRIPTION
### Why

#1645 reports two TypeScript errors that both still reproduce on `next` but are working-as-designed:

- `SpringValues<T>` is not structurally `React.CSSProperties` — each entry is a `SpringValue` instance, not a primitive. Typing a child component's prop as `CSSProperties` is too narrow.
- Strict literal unions like `CSSProperties['pointerEvents']` deliberately reject `SpringValue<string>` so typos inside `useSpring` (`pointerEvents: 'fooo'`) stay caught. The error people hit is TS widening a ternary like `showMenu ? 'all' : 'none'` to `string` at the config seam.

Loosening either type would weaken safety for everyone to paper over patterns that have clean call-site fixes. Better to document the patterns.

### Changes

- Expanded the `SpringValues` glossary entry with subsections for child-component typing and literal-value widening.
- Added a *Typing components that receive animated styles* section to the Animated Elements concept page.
- Added `SpringValues` to the `useTransition` TS Glossary list (was missing).

Closes #1645