### PR TITLE
feat(core): add `reverse` prop to useTransition

### DIFF
--- a/.changeset/reverse-transition-trail.md
+++ b/.changeset/reverse-transition-trail.md
@@ -1,0 +1,5 @@
+---
+'@react-spring/core': minor
+---
+
+Add a `reverse` prop to `useTransition` that flips the order in which `trail` delays are assigned to transitioning items. Toggle it with caller state (e.g. `reverse: !open`) to make items animate in forward on `enter` and backward on `leave`. Render order is untouched — use `sort` for that. Closes #1794.

--- a/docs/app/data/fixtures.tsx
+++ b/docs/app/data/fixtures.tsx
@@ -687,6 +687,22 @@ export const TRANSITION_CONFIG_DATA: CellData[][] = [
     null,
   ],
   ['trail', 'number', '0'],
+  [
+    {
+      label: 'reverse',
+      content: (
+        <p>
+          Reverses the order in which <code>trail</code> delays are assigned to
+          transitioning items. Toggle with your open/close state (e.g.{' '}
+          <code>reverse: !open</code>) to animate in forward on{' '}
+          <code>enter</code> and backward on <code>leave</code>. Does not affect
+          render order — use <code>sort</code> for that.
+        </p>
+      ),
+    },
+    'boolean',
+    'false',
+  ],
   ['exitBeforeEnter', 'boolean', 'false'],
   [
     {

--- a/packages/core/src/hooks/useTransition.test.tsx
+++ b/packages/core/src/hooks/useTransition.test.tsx
@@ -224,6 +224,66 @@ describe('useTransition', () => {
     // New items should now be visible
     expect(rendered).toEqual([2, 3])
   })
+
+  describe('when "reverse" is true', () => {
+    // Regression for https://github.com/pmndrs/react-spring/issues/1794 —
+    // reverses the trail order so items can animate in forward on enter
+    // and backward on leave by toggling `reverse` with caller state.
+    it('reverses the trail order across leaving items', async () => {
+      const leaveStart: number[] = []
+      const props: UseTransitionProps<number> = {
+        from: { n: 0 },
+        enter: { n: 1 },
+        leave: item => ({
+          n: 0,
+          onStart: () => leaveStart.push(item),
+        }),
+        trail: 100,
+        reverse: true,
+      }
+
+      await update([0, 1, 2], props)
+      await global.advanceUntilIdle()
+
+      await update([], props)
+
+      global.mockRaf.step()
+      expect(leaveStart).toEqual([2])
+
+      await global.advanceByTime(100)
+      expect(leaveStart).toEqual([2, 1])
+
+      await global.advanceByTime(100)
+      expect(leaveStart).toEqual([2, 1, 0])
+    })
+
+    it('keeps trail order forward when reverse is false (default)', async () => {
+      const leaveStart: number[] = []
+      const props: UseTransitionProps<number> = {
+        from: { n: 0 },
+        enter: { n: 1 },
+        leave: item => ({
+          n: 0,
+          onStart: () => leaveStart.push(item),
+        }),
+        trail: 100,
+      }
+
+      await update([0, 1, 2], props)
+      await global.advanceUntilIdle()
+
+      await update([], props)
+
+      global.mockRaf.step()
+      expect(leaveStart).toEqual([0])
+
+      await global.advanceByTime(100)
+      expect(leaveStart).toEqual([0, 1])
+
+      await global.advanceByTime(100)
+      expect(leaveStart).toEqual([0, 1, 2])
+    })
+  })
 })
 
 let result: Awaited<ReturnType<typeof render>> | undefined

--- a/packages/core/src/hooks/useTransition.tsx
+++ b/packages/core/src/hooks/useTransition.tsx
@@ -81,6 +81,7 @@ export function useTransition(
     reset,
     sort,
     trail = 0,
+    reverse = false,
     expires = true,
     exitBeforeEnter = false,
     onDestroyed,
@@ -197,6 +198,12 @@ export function useTransition(
 
   // Track cumulative delay for the "trail" prop.
   let delay = -trail
+  // Payloads that received a trail-step delay, in iteration order. Used to
+  // flip the trail when `reverse` is true.
+  const trailedPayloads: Array<{
+    payload: ControllerUpdate<UnknownProps>
+    propsDelay: number
+  }> = []
 
   // Expired transitions use this to dismount.
   const forceUpdate = useForceUpdate()
@@ -341,6 +348,8 @@ export function useTransition(
 
     const springs = getSprings(t.ctrl, payload)
 
+    trailedPayloads.push({ payload, propsDelay })
+
     /**
      * Make a separate map for the exiting changes and "regular" changes
      */
@@ -350,6 +359,17 @@ export function useTransition(
       changes.set(t, { phase, springs, payload })
     }
   })
+
+  // When `reverse` is true, flip the trail step so the last transitioning
+  // item gets delay 0 and the first gets `(N - 1) * trail`. Payload refs are
+  // the same objects stored in `changes` / `exitingTransitions`, so mutating
+  // them updates the values the effect reads later.
+  if (reverse && trail) {
+    const total = trailedPayloads.length
+    each(trailedPayloads, ({ payload, propsDelay }, i) => {
+      payload.delay = propsDelay + (total - 1 - i) * trail
+    })
+  }
 
   // The prop overrides from an ancestor.
   const context = useContext(SpringContext)

--- a/packages/core/src/types/transition.ts
+++ b/packages/core/src/types/transition.ts
@@ -63,6 +63,18 @@ export type UseTransitionProps<Item = any> = Merge<
     keys?: ItemKeys<Item>
     sort?: (a: Item, b: Item) => number
     trail?: number
+    /**
+     * Reverses the order in which `trail` delays are assigned to transitioning
+     * items. When `true`, the last visible item starts first and the trail
+     * accumulates backward across the remaining items. Does not affect render
+     * order — use `sort` for that.
+     *
+     * Toggle this with your open/close state (e.g. `reverse: !open`) to make
+     * items animate in forward on `enter` and backward on `leave`.
+     *
+     * @default false
+     */
+    reverse?: boolean
     exitBeforeEnter?: boolean
     /**
      * When `true` or `<= 0`, each item is unmounted immediately after its


### PR DESCRIPTION
Closes #1794.

`useTransition` lost the v8-era `transition.reverse()` capability when the API became a render function. There is no built-in way today to make items trail forward on `enter` but backward on `leave`; the existing `sort` prop reverses display order, not trail delay order.

### Approach

Adds `reverse?: boolean` to `UseTransitionProps`. When `true`, the order in which `trail` delays are assigned is flipped so the last visible item starts first and the trail accumulates backward across the remaining items. Toggle it with caller state (e.g. `reverse: !open`) to flip behaviour between enter and leave phases.

`reverse` is scoped to trail delay assignment only — render order is untouched, and `sort` remains the prop for display order. Two orthogonal concerns, two props. Backwards-compatible default `false`.

Items that don't actually transition this render (stable items with no `update` prop, items already mid-leave) stay outside the trail accumulator, so `reverse` only flips the items that are animating — same scope as `trail` itself.
