### PR TITLE
fix(core): fire onRest when animation is cancelled before its first frame

### DIFF
--- a/.changeset/onrest-cancelled-before-first-frame.md
+++ b/.changeset/onrest-cancelled-before-first-frame.md
@@ -1,0 +1,5 @@
+---
+'@react-spring/core': patch
+---
+
+Fire `onRest` when an animation is cancelled before its first frame. `SpringValue._stop` gated `onRest` on `anim.changed`, which only becomes `true` once a frame has rendered. When two `start()` calls happened within a single tick and the second returned the spring to its current value, the engine stopped the animation before any frame fired, so `onRest` was silently dropped. The same gap affected `set()` and `stop()` called synchronously after `start()`. Closes #1802.

--- a/packages/core/src/SpringValue.test.ts
+++ b/packages/core/src/SpringValue.test.ts
@@ -956,6 +956,21 @@ function describeEvents() {
       global.mockRaf.step()
       expect(onRest).toBeCalledTimes(1)
     })
+    // https://github.com/pmndrs/react-spring/issues/1802
+    it('is called when two starts cancel each other before the first frame', async () => {
+      const onRest = vi.fn()
+      const spring = new SpringValue({ from: 0, onRest })
+
+      // Both starts happen synchronously, before any rAF tick.
+      // The second start returns to the current value, so the engine
+      // stops the animation before any frame has rendered.
+      spring.start(1)
+      spring.start(0)
+
+      await global.advanceUntilIdle()
+
+      expect(onRest).toBeCalled()
+    })
   })
 }
 

--- a/packages/core/src/SpringValue.ts
+++ b/packages/core/src/SpringValue.ts
@@ -1026,10 +1026,8 @@ export class SpringValue<T = any> extends FrameValue<T> {
         : getFinishedResult(this.get(), checkFinished(this, goal ?? anim.to))
 
       flushCalls(this._pendingCalls, result)
-      if (anim.changed) {
-        anim.changed = false
-        sendEvent(this, 'onRest', result, this)
-      }
+      anim.changed = false
+      sendEvent(this, 'onRest', result, this)
     }
   }
 }


### PR DESCRIPTION
Closes #1802.

### Summary

`SpringValue._stop` gated `onRest` on `anim.changed`, which only flips to `true` once the first frame has rendered. When two `start()` calls happen within a single tick and the second returns the spring to its current value, the engine stops the animation before any frame fires — so `onRest` was silently dropped while the start promise still resolved. The same gap affected `set()` and `stop()` called synchronously after `start()`.

Entry to the block already requires `isAnimating(this)`, so dropping the `anim.changed` guard just covers the gap where a spring transitioned active → idle without rendering a frame. The full unit suite passes (253 / 0).

### Repro

```ts
const [, api] = useSpring(() => ({
  opacity: 0,
  onRest: (v) => console.log('rest', v.value),
}))

api.start({ opacity: 1 })
api.start({ opacity: 0 }) // before the next rAF — onRest never fires
```
