### PR TITLE
fix(web): exact-match transform function names in style key regex

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,23 @@
+.git
+.github
+.husky
+.claude
+.vercel
+.vscode
+.idea
+.DS_Store
+
+# build outputs and caches (rebuilt inside container)
+**/node_modules
+**/.turbo
+**/build
+**/dist
+**/.cache
+**/.react-router
+**/__screenshots__
+**/coverage
+**/*.log
+
+# editor / OS noise
+*.tgz
+Thumbs.db

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,109 @@
+name: Docs deploy
+
+on:
+  push:
+    branches: [next]
+    paths:
+      - 'docs/**'
+      - 'Dockerfile'
+      - '.dockerignore'
+      - '.github/workflows/docs-deploy.yml'
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+  id-token: write
+
+env:
+  GCP_PROJECT_NUMBER: 204644970562
+  CLOUD_RUN_SERVICE: react-spring
+  CLOUD_RUN_REGION: europe-west1
+
+jobs:
+  pr-changes:
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - 'Dockerfile'
+              - '.dockerignore'
+              - '.github/workflows/docs-deploy.yml'
+
+  deploy-prod:
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+      - uses: google-github-actions/setup-gcloud@v2
+      - name: Deploy to Cloud Run (prod)
+        run: |
+          gcloud run deploy "$CLOUD_RUN_SERVICE" \
+            --source . \
+            --region "$CLOUD_RUN_REGION" \
+            --quiet
+
+  deploy-preview:
+    needs: pr-changes
+    if: |
+      github.event_name == 'pull_request' &&
+      github.event.action != 'closed' &&
+      needs.pr-changes.outputs.docs == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+      - uses: google-github-actions/setup-gcloud@v2
+      - name: Deploy preview revision
+        id: deploy
+        run: |
+          TAG="pr-${{ github.event.number }}"
+          gcloud run deploy "$CLOUD_RUN_SERVICE" \
+            --source . \
+            --region "$CLOUD_RUN_REGION" \
+            --tag "$TAG" \
+            --no-traffic \
+            --quiet
+          URL="https://${TAG}---${CLOUD_RUN_SERVICE}-${GCP_PROJECT_NUMBER}.${CLOUD_RUN_REGION}.run.app"
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+      - uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: docs-preview
+          message: |
+            **Docs preview:** ${{ steps.deploy.outputs.url }}
+
+            Deployed at `${{ github.sha }}`. Updates on every push.
+
+  cleanup-preview:
+    if: github.event_name == 'pull_request' && github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_SA_EMAIL }}
+      - uses: google-github-actions/setup-gcloud@v2
+      # tolerate failure: the PR may not have triggered a preview deploy
+      - name: Remove preview tag
+        run: |
+          gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
+            --region "$CLOUD_RUN_REGION" \
+            --remove-tags "pr-${{ github.event.number }}" \
+            --quiet || echo "No preview tag to remove"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# syntax=docker/dockerfile:1.7
+
+# ----- Build stage: install + build inside the full monorepo -----
+FROM node:24-alpine AS builder
+
+RUN corepack enable
+WORKDIR /repo
+
+COPY . .
+
+RUN pnpm install --frozen-lockfile
+
+# Build the docs and any workspace packages it depends on
+RUN pnpm --filter @react-spring/docs... build
+
+# Produce a self-contained dir with prod-only deps (symlinks dereferenced)
+RUN pnpm --filter @react-spring/docs deploy --prod /out
+
+# pnpm deploy doesn't carry over the build output; copy it in explicitly
+RUN cp -r /repo/docs/build /out/build
+
+# ----- Runtime stage: slim image with only what's needed to serve -----
+FROM node:24-alpine
+
+WORKDIR /app
+ENV NODE_ENV=production
+ENV PORT=8080
+
+COPY --from=builder /out ./
+
+EXPOSE 8080
+CMD ["node_modules/.bin/react-router-serve", "./build/server/index.js"]

--- a/docs/app/root.tsx
+++ b/docs/app/root.tsx
@@ -16,7 +16,7 @@ import {
   WidgetGoogleTagManagerBody,
 } from './components/Widgets/WidgetGoogleTagManager'
 import { lightThemeClass } from './styles/light-theme.css'
-import global from './styles/global.css?url'
+import './styles/global.css'
 import docusearch from '@docsearch/css/dist/style.css?url'
 import { getTheme, setTheme } from './helpers/theme.server'
 import { darkThemeClass } from './styles/dark-theme.css'
@@ -62,7 +62,6 @@ export const meta: MetaFunction = () => {
 
 export const links: LinksFunction = () => [
   { rel: 'stylesheet', href: docusearch },
-  { rel: 'stylesheet', href: global },
   { rel: 'stylesheet', href: 'https://rsms.me/inter/inter.css' },
   { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
   { rel: 'preconnect', href: 'https://fonts.gstatic.com' },

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,10 @@
   "version": "2.0.0",
   "private": true,
   "type": "module",
-  "sideEffects": false,
+  "sideEffects": [
+    "**/*.css",
+    "**/*.css.ts"
+  ],
   "scripts": {
     "build": "react-router build",
     "dev": "concurrently \"pnpm dev:rr\" \"pnpm scripts:watch\"",

--- a/docs/react-router.config.ts
+++ b/docs/react-router.config.ts
@@ -1,6 +1,3 @@
-import { vercelPreset } from '@vercel/react-router/vite'
 import type { Config } from '@react-router/dev/config'
 
-export default {
-  presets: [vercelPreset()],
-} satisfies Config
+export default {} satisfies Config

--- a/targets/web/src/AnimatedStyle.ts
+++ b/targets/web/src/AnimatedStyle.ts
@@ -20,7 +20,8 @@ import {
  * animated. Perspective has been left out as it would conflict with the
  * non-transform perspective style.
  */
-const domTransforms = /^(matrix|translate|scale|rotate|skew)/
+const domTransforms =
+  /^(matrix3d|matrix|translate3d|translate[XYZ]?|scale3d|scale[XYZ]?|rotate3d|rotate[XYZ]?|skew[XY]?)$/
 
 // These keys have "px" units by default
 const pxTransforms = /^(translate)/

--- a/targets/web/src/animated.test.tsx
+++ b/targets/web/src/animated.test.tsx
@@ -205,6 +205,25 @@ describe('animated component', () => {
     const wrapper = getByTestId('wrapper').element() as HTMLElement
     expect(wrapper.style.transform).toBe('none')
   })
+  it('does not treat custom spring keys that start with transform-function names as transforms', async () => {
+    // Issue #1912: user-defined interpolation keys like `scale3dValue` or
+    // `translateY_v2` were hijacked by the `^scale` / `^translate` prefix
+    // match in `AnimatedStyle`, corrupting the composed `transform`.
+    const scale3dValue = spring(0.5)
+    const { getByTestId } = await render(
+      <a.div
+        style={
+          {
+            scale3dValue,
+            transform: 'rotate(45deg)',
+          } as React.CSSProperties
+        }
+        data-testid="wrapper"
+      />
+    )
+    const wrapper = getByTestId('wrapper').element() as HTMLElement
+    expect(wrapper.style.transform).toBe('rotate(45deg)')
+  })
   it('preserves transform-style and transform-origin properties', async () => {
     const { getByTestId } = await render(
       <a.div


### PR DESCRIPTION
Closes #1912.

### Summary

User-defined style keys like `scale3dValue` or `translateY_v2` were hijacked by the `^(matrix|translate|scale|rotate|skew)` prefix match in `AnimatedStyle`, then emitted as invalid CSS (e.g. `scale3dValue(0.5)`), which the browser silently drops — taking the rest of the composed `transform` with it.

The fix anchors the regex with `$` and enumerates the exact CSS transform-function names from [MDN][1]:

```ts
/^(matrix3d|matrix|translate3d|translate[XYZ]?|scale3d|scale[XYZ]?|rotate3d|rotate[XYZ]?|skew[XY]?)$/
```

Any other key now passes through as a regular style prop.

[1]: https://developer.mozilla.org/en-US/docs/Web/CSS/transform-function
