### PR TITLE
fix(core): floor adaptive precision at float resolution to let springs settle on sub-precision drift

### DIFF
--- a/.changeset/spring-precision-floor.md
+++ b/.changeset/spring-precision-floor.md
@@ -1,0 +1,5 @@
+---
+'@react-spring/core': patch
+---
+
+Floor the spring's adaptive precision at the smallest difference doubles can represent around the values being animated. Previously, when a caller's layout math introduced tiny floating-point drift on the target (e.g. `Math.cos(Math.PI / 2)` returning `6e-17` instead of `0`, so a "logical 160" arrived as `159.99999999999997`), the adaptive precision collapsed to a value smaller than any delta the spring could express, so the animation never settled and the awaited `start()` promise never resolved. Closes #2208.

--- a/packages/core/src/Controller.test.ts
+++ b/packages/core/src/Controller.test.ts
@@ -720,4 +720,31 @@ describe('Controller', () => {
       expect(onRest).toHaveBeenCalled()
     })
   })
+
+  // Regression test for https://github.com/pmndrs/react-spring/issues/2208
+  it('settles when a target differs from the current value by less than float precision', async () => {
+    // Caller-side trigonometry produces a tiny floating-point drift:
+    // `Math.cos(Math.PI / 2)` returns `6.12e-17` rather than exactly `0`, so
+    // the "logical 160" the caller intended becomes `159.99999999999997`. The
+    // current value is exactly `160`, and the difference is smaller than what
+    // doubles can represent at that magnitude — but not `=== 0`, so the
+    // spring previously entered animation with an unsatisfiable adaptive
+    // precision and never settled.
+    const driftedTarget = 160 * Math.cos(Math.PI + Math.PI / 2) + 160
+    expect(driftedTarget).not.toBe(160)
+    expect(Math.abs(driftedTarget - 160)).toBeLessThan(1e-13)
+
+    const ctrl = new Controller({ x: 160, y: 0, scale: 1 })
+
+    let resolved = false
+    const promise = ctrl.start({ x: driftedTarget, y: 110, scale: 0 })
+    void promise.then(() => (resolved = true))
+
+    await global.advanceUntilIdle()
+    await flushMicroTasks()
+
+    expect(resolved).toBe(true)
+    const result = await promise
+    expect(result.finished).toBe(true)
+  })
 })

--- a/packages/core/src/SpringValue.ts
+++ b/packages/core/src/SpringValue.ts
@@ -223,9 +223,20 @@ export class SpringValue<T = any> extends FrameValue<T> {
          * TODO: make this value ~0.0001 by default in next breaking change
          * for more info see – https://github.com/pmndrs/react-spring/issues/1389
          */
+        // Floor the adaptive default at the smallest difference doubles can
+        // represent around the values being animated. Without this, callers
+        // whose layout math introduces floating-point drift (e.g.
+        // `Math.cos(Math.PI / 2)` returning `6e-17` instead of `0`) produce a
+        // precision smaller than any delta the spring can express, so the
+        // spring never settles. See #2208.
         const precision =
           config.precision ||
-          (from == to ? 0.005 : Math.min(1, Math.abs(to - from) * 0.001))
+          (from == to
+            ? 0.005
+            : Math.max(
+                Math.max(Math.abs(to), Math.abs(from), 1) * Number.EPSILON,
+                Math.min(1, Math.abs(to - from) * 0.001)
+              ))
 
         // Duration easing
         if (!is.und(config.duration)) {


### PR DESCRIPTION
Closes #2208.

### Summary

When a caller passes a target value to `controller.start()` that differs from the current value by less than the smallest difference doubles can represent at that magnitude, the spring entered animation with an adaptive precision the math could never satisfy — so the animation never finished and the awaited `start()` promise never resolved. The original repro is layout code computing positions with `Math.cos(Math.PI / 2)`: JS returns `6.12e-17` instead of `0`, so a "logical `160`" target arrives as `159.99999999999997`. `isEqual(160, 159.99999999999997)` is `false`, the spring sees a non-zero distance, and the adaptive precision (`|to - from| * 0.001 ≈ 3.5e-18`) is unrepresentable. The spring drifts forever; `frameLoop` never goes idle.

The fix floors the adaptive default at `max(|to|, |from|, 1) * Number.EPSILON` — the smallest meaningful precision for the values being animated. Caller-supplied `config.precision` and the `from === to` fast path are unchanged.

### Repro

```ts
const ctrl = new Controller({ x: 160, y: 0, scale: 1 })
const driftedTarget = 160 * Math.cos(Math.PI + Math.PI / 2) + 160
// 159.99999999999997 — sub-precision drift from 160

await ctrl.start({ x: driftedTarget, y: 110, scale: 0 })
// previously never resolved
```
