### PR TITLE
docs(core): clarify null/undefined goals are skipped, not animated

### DIFF
--- a/docs/app/routes/docs.advanced.spring-value.mdx
+++ b/docs/app/routes/docs.advanced.spring-value.mdx
@@ -27,6 +27,15 @@ Meanwhile you pass the `SpringValue` to your `animated` component. Any type is v
 Types that cannot be animated are basically immediate: true animations. Such types include:
 a `boolean`, a display string like `"none"`, etc.
 
+> **`null` and `undefined` mean "leave this value alone".** They are not goals — a
+> spring cannot animate _to_ `null`. When a key's value is `null`/`undefined` (or
+> `false`) it is skipped, and the spring keeps whatever value it already holds. A key
+> that has _only ever_ been `null`/`undefined` is never created at all.
+>
+> If you need to represent "no value", model it explicitly rather than relying on the
+> spring to store `null` — for example keep the nullable state in React and feed the
+> spring a real number (or toggle `immediate`/visibility) based on it.
+
 ```tsx
 import { Component, createRef } from 'react'
 import { SpringValue, animated } from '@react-spring/web'


### PR DESCRIPTION
Documents the long-standing contract that `null`/`undefined` (and `false`) in a spring goal mean "leave this value alone" rather than a target to animate towards — a spring cannot animate _to_ `null`. This surfaces in [#2295](https://github.com/pmndrs/react-spring/issues/2295), where the silent skip is mistaken for a bug.

The note is added to the existing "Any type is valid…" paragraph on the SpringValue page, which is where the animatable-types behaviour is already described.

### Why

- The skip semantics are intentional and type-supported (`GoalValues<T>` allows `| null`), but undocumented for users.
- Animating a numeric value toward `null` is meaningless — there is nothing to interpolate to — so `null` is reserved for partial updates that leave a key untouched.
- Points users at the correct pattern: keep nullable state in React and drive the spring from it.

### Related issues

* closes #2295
