### PR TITLE
fix(shared): guard string interpolator against number-less output values

### DIFF
--- a/.changeset/string-interpolator-null-match.md
+++ b/.changeset/string-interpolator-null-match.md
@@ -1,0 +1,5 @@
+---
+'@react-spring/shared': patch
+---
+
+Stop the string interpolator throwing `Cannot read properties of null (reading 'map')` when an output value contains no numbers. Strings like `boxShadow: 'none'` or an unresolved CSS variable that falls through as its literal `var(--x)` text now extract to no numeric tokens and interpolate gracefully instead of hitting a null `String.match`. Closes #2327.

--- a/packages/shared/src/stringInterpolation.test.ts
+++ b/packages/shared/src/stringInterpolation.test.ts
@@ -1,0 +1,18 @@
+import { createStringInterpolator } from './stringInterpolation'
+import { colors } from './colors'
+import { Globals } from '.'
+
+beforeAll(() => {
+  Globals.assign({ createStringInterpolator, colors })
+})
+
+// https://github.com/pmndrs/react-spring/issues/2327
+it('interpolates a number-less output value instead of throwing on a null match', () => {
+  const interpolate = createStringInterpolator({
+    range: [0, 1],
+    output: ['none', '0px 4px 8px rgba(0, 0, 0, 0.5)'],
+  })
+
+  expect(interpolate(0)).toBe('none')
+  expect(interpolate(0.5)).toBe('none')
+})

--- a/packages/shared/src/stringInterpolation.ts
+++ b/packages/shared/src/stringInterpolation.ts
@@ -21,6 +21,12 @@ let namedColorRegex: RegExp
 const rgbaRound = (_: any, p1: number, p2: number, p3: number, p4: number) =>
   `rgba(${Math.round(p1)}, ${Math.round(p2)}, ${Math.round(p3)}, ${p4})`
 
+// Extract the numeric tokens from a string. Strings with no numbers — e.g.
+// `boxShadow: 'none'` or an unresolved CSS variable that falls through as its
+// literal `var(--x)` text — yield `[]` rather than throwing on a null match.
+// See https://github.com/pmndrs/react-spring/issues/2327
+const getNumbers = (value: string) => value.match(numberRegex) ?? []
+
 /**
  * Supports string shapes by extracting numbers so new values can be computed,
  * and recombines those values into new strings of the same shape.  Supports
@@ -50,7 +56,7 @@ export const createStringInterpolator = (
   })
 
   // Convert ["1px 2px", "0px 0px"] into [[1, 2], [0, 0]]
-  const keyframes = output.map(value => value.match(numberRegex)!.map(Number))
+  const keyframes = output.map(value => getNumbers(value).map(Number))
 
   // Convert ["1px 2px", "0px 0px"] into [[1, 0], [2, 0]]
   const outputRanges = keyframes[0].map((_, i) =>
@@ -74,9 +80,9 @@ export const createStringInterpolator = (
   // a whole number. Whole-number keyframes are left untouched so that
   // values like the alpha channel in `rgba(…, 0)` → `rgba(…, 1)` keep
   // their natural sub-frame precision.
-  const decimalCounts = output[0].match(numberRegex)!.map((_, pos) => {
+  const decimalCounts = getNumbers(output[0]).map((_, pos) => {
     const counts = output.map(value => {
-      const token = value.match(numberRegex)![pos]
+      const token = getNumbers(value)[pos]
       const dot = token.indexOf('.')
       return dot === -1 ? 0 : token.length - dot - 1
     })


### PR DESCRIPTION
Animating a string prop whose output includes a value with no numbers — most commonly `boxShadow: 'none'`, or an unresolved CSS variable that falls through as its literal `var(--x)` text — crashed at runtime with the cryptic `TypeError: Cannot read properties of null (reading 'map')`. The string interpolator extracts numeric tokens with `String.match(numberRegex)`, which returns `null` for such strings, and a non-null assertion (`!`) let `.map` run on `null`.

This routes the three token extractions through a null-safe helper, so a number-less value yields no tokens and degrades gracefully instead of throwing. Inputs that already worked are unaffected — the assertion was compile-time only, so the fallback path is reachable solely where the code used to crash.

Closes #2327.

### Behaviour

- `['none', '0px 4px 8px rgba(0, 0, 0, 0.5)']` no longer throws; in-between frames return `'none'`.
- An unresolved CSS variable that resolves to its literal text no longer throws (the root cause behind #1952).
