### PR TITLE
fix(animated): WeakMap fallback for non-extensible component caching

### DIFF
--- a/.changeset/non-extensible-component-cache.md
+++ b/.changeset/non-extensible-component-cache.md
@@ -1,0 +1,9 @@
+---
+'@react-spring/animated': patch
+---
+
+Fix `cannot add a new property` crash when wrapping non-extensible React Native host components.
+
+`createHost` cached animated wrappers by writing directly to the component object via `Component[Symbol.for('AnimatedComponent')] = ...`. On Hermes (React Native), host components like `View`, `Text`, and `Image` become non-extensible after their first JSX render, causing a `TypeError` in strict mode.
+
+The fix attempts the direct write first (fast path, no change for extensible components) and falls back to a module-level `WeakMap` when the write is rejected.

--- a/packages/animated/src/createHost.test.ts
+++ b/packages/animated/src/createHost.test.ts
@@ -1,5 +1,4 @@
 import { createHost } from './createHost'
-import { withAnimated } from './withAnimated'
 import { AnimatedObject } from './AnimatedObject'
 
 const hostConfig = {
@@ -10,7 +9,9 @@ const hostConfig = {
 
 describe('createHost', () => {
   it('caches the animated wrapper on the component itself', () => {
-    function MyComponent() {}
+    function MyComponent() {
+      return null
+    }
     const { animated } = createHost({ MyComponent }, hostConfig)
 
     const A = animated(MyComponent)
@@ -21,7 +22,9 @@ describe('createHost', () => {
   })
 
   it('falls back to a WeakMap when the component is non-extensible', () => {
-    function MyComponent() {}
+    function MyComponent() {
+      return null
+    }
     Object.preventExtensions(MyComponent)
 
     // Should not throw even though MyComponent is non-extensible
@@ -36,7 +39,9 @@ describe('createHost', () => {
   })
 
   it('handles frozen components without throwing', () => {
-    function MyComponent() {}
+    function MyComponent() {
+      return null
+    }
     Object.freeze(MyComponent)
 
     const { animated } = createHost({ MyComponent }, hostConfig)
@@ -46,7 +51,9 @@ describe('createHost', () => {
   })
 
   it('sets displayName on the animated wrapper', () => {
-    function NamedComponent() {}
+    function NamedComponent() {
+      return null
+    }
     const { animated } = createHost({ NamedComponent }, hostConfig)
 
     const A = animated(NamedComponent)
@@ -54,7 +61,9 @@ describe('createHost', () => {
   })
 
   it('sets displayName on wrappers for non-extensible components', () => {
-    function NamedComponent() {}
+    function NamedComponent() {
+      return null
+    }
     Object.preventExtensions(NamedComponent)
 
     const { animated } = createHost({ NamedComponent }, hostConfig)

--- a/packages/animated/src/createHost.test.ts
+++ b/packages/animated/src/createHost.test.ts
@@ -1,0 +1,65 @@
+import { createHost } from './createHost'
+import { withAnimated } from './withAnimated'
+import { AnimatedObject } from './AnimatedObject'
+
+const hostConfig = {
+  applyAnimatedValues: () => false,
+  createAnimatedStyle: (style: object) => new AnimatedObject(style),
+  getComponentProps: (props: object) => props,
+}
+
+describe('createHost', () => {
+  it('caches the animated wrapper on the component itself', () => {
+    function MyComponent() {}
+    const { animated } = createHost({ MyComponent }, hostConfig)
+
+    const A = animated(MyComponent)
+    const B = animated(MyComponent)
+
+    // Same wrapper is returned on repeated calls
+    expect(A).toBe(B)
+  })
+
+  it('falls back to a WeakMap when the component is non-extensible', () => {
+    function MyComponent() {}
+    Object.preventExtensions(MyComponent)
+
+    // Should not throw even though MyComponent is non-extensible
+    const { animated } = createHost({ MyComponent }, hostConfig)
+
+    const A = animated(MyComponent)
+    expect(A).toBeDefined()
+
+    // Calling again returns the same cached wrapper
+    const B = animated(MyComponent)
+    expect(A).toBe(B)
+  })
+
+  it('handles frozen components without throwing', () => {
+    function MyComponent() {}
+    Object.freeze(MyComponent)
+
+    const { animated } = createHost({ MyComponent }, hostConfig)
+
+    expect(() => animated(MyComponent)).not.toThrow()
+    expect(animated(MyComponent)).toBeDefined()
+  })
+
+  it('sets displayName on the animated wrapper', () => {
+    function NamedComponent() {}
+    const { animated } = createHost({ NamedComponent }, hostConfig)
+
+    const A = animated(NamedComponent)
+    expect(A.displayName).toBe('Animated(NamedComponent)')
+  })
+
+  it('sets displayName on wrappers for non-extensible components', () => {
+    function NamedComponent() {}
+    Object.preventExtensions(NamedComponent)
+
+    const { animated } = createHost({ NamedComponent }, hostConfig)
+    const A = animated(NamedComponent)
+
+    expect(A.displayName).toBe('Animated(NamedComponent)')
+  })
+})

--- a/packages/animated/src/createHost.ts
+++ b/packages/animated/src/createHost.ts
@@ -22,6 +22,12 @@ type WithAnimated = {
 // For storing the animated version on the original component
 const cacheKey = Symbol.for('AnimatedComponent')
 
+// Fallback cache for component objects that are non-extensible (e.g. React
+// Native host components on Hermes after their first JSX render). We try to
+// write the cached wrapper on the component itself first; if that throws we
+// fall back to this WeakMap so that `animated(View)` keeps working.
+const fallbackCache = new WeakMap<object, any>()
+
 export const createHost = (
   components: AnimatableComponent[] | { [key: string]: AnimatableComponent },
   {
@@ -44,9 +50,18 @@ export const createHost = (
         animated[Component] ||
         (animated[Component] = withAnimated(Component, hostConfig))
     } else {
-      Component =
-        Component[cacheKey] ||
-        (Component[cacheKey] = withAnimated(Component, hostConfig))
+      let cached = Component[cacheKey] ?? fallbackCache.get(Component)
+      if (!cached) {
+        cached = withAnimated(Component, hostConfig)
+        try {
+          Component[cacheKey] = cached
+        } catch {
+          // Component is non-extensible (e.g. a Hermes-optimised React Native
+          // host component). Store in the module-level WeakMap instead.
+        }
+        fallbackCache.set(Component, cached)
+      }
+      Component = cached
     }
 
     Component.displayName = `Animated(${displayName})`


### PR DESCRIPTION
Fixes #2533

## Problem

`createHost` caches animated wrappers via `Component[cacheKey] = ...`. On Hermes, React Native host components (`View`, `Text`, `Image`) become non-extensible after their first JSX render — writing a new property throws `TypeError: cannot add a new property` in strict mode.

This crashes `@react-spring/native`'s module initialization when loaded lazily (e.g. with Metro `inlineRequires: true`), because `createHost` runs at module scope iterating over those exact primitives.

## Fix

Try the direct write first (fast path, no change for extensible components). On failure, fall back to a module-level `WeakMap`.

```diff
+const fallbackCache = new WeakMap<object, any>()

 const animated: WithAnimated = (Component: any) => {
   if (is.str(Component)) {
     Component = animated[Component] || (animated[Component] = withAnimated(Component, hostConfig))
   } else {
-    Component = Component[cacheKey] || (Component[cacheKey] = withAnimated(Component, hostConfig))
+    let cached = Component[cacheKey] ?? fallbackCache.get(Component)
+    if (!cached) {
+      cached = withAnimated(Component, hostConfig)
+      try {
+        Component[cacheKey] = cached
+      } catch {
+        // non-extensible component — store in WeakMap fallback
+      }
+      fallbackCache.set(Component, cached)
+    }
+    Component = cached
   }
 }
```

## Context

This was found while enabling Metro's `inlineRequires: true` + `experimentalImportSupport: true` in a large React Native monorepo. A local Yarn patch on `@react-spring/animated@10.0.3` with this exact fix is already shipping in production while we wait for an upstream release: https://coinbase.ghe.com/consumer/react-native/pull/new/acalazans/metro-inline-requires-enable