### PR TITLE
test: expand public-API coverage across core, web and parallax

### DIFF
--- a/packages/core/src/SpringRef.test.ts
+++ b/packages/core/src/SpringRef.test.ts
@@ -1,0 +1,138 @@
+import { Controller } from './Controller'
+import { SpringRef } from './SpringRef'
+
+// `useSpring`/`useTransition` already guard the React-side wiring of an injected
+// ref (deferral, event firing, StrictMode double-mount). These tests exercise
+// the imperative `SpringRef` API itself, which had no dedicated coverage.
+describe('SpringRef', () => {
+  it('adds and removes controllers, ignoring duplicates', () => {
+    const ref = SpringRef()
+    const a = new Controller({ x: 0 })
+    const b = new Controller({ x: 0 })
+
+    ref.add(a)
+    ref.add(b)
+    ref.add(a) // duplicate is ignored
+    expect(ref.current).toEqual([a, b])
+
+    ref.delete(a)
+    expect(ref.current).toEqual([b])
+  })
+
+  it('starts every controller with shared props', async () => {
+    const ref = SpringRef()
+    const a = new Controller({ x: 0 })
+    const b = new Controller({ x: 0 })
+    ref.add(a)
+    ref.add(b)
+
+    ref.start({ x: 100 })
+    await global.advanceUntilIdle()
+
+    expect(a.springs.x.get()).toBe(100)
+    expect(b.springs.x.get()).toBe(100)
+  })
+
+  it('passes the index to a start function for per-controller props', async () => {
+    const ref = SpringRef()
+    const a = new Controller({ x: 0 })
+    const b = new Controller({ x: 0 })
+    ref.add(a)
+    ref.add(b)
+
+    ref.start(i => ({ x: (i + 1) * 100 }))
+    await global.advanceUntilIdle()
+
+    expect(a.springs.x.get()).toBe(100)
+    expect(b.springs.x.get()).toBe(200)
+  })
+
+  it('set() updates values instantly without animating', () => {
+    const ref = SpringRef()
+    const a = new Controller({ x: 0 })
+    ref.add(a)
+
+    ref.set({ x: 50 })
+    // No frames advanced — set is synchronous.
+    expect(a.springs.x.get()).toBe(50)
+  })
+
+  it('set() accepts a function for per-controller values', () => {
+    const ref = SpringRef()
+    const a = new Controller({ x: 0 })
+    const b = new Controller({ x: 0 })
+    ref.add(a)
+    ref.add(b)
+
+    ref.set((i: number) => ({ x: i * 10 }))
+    expect(a.springs.x.get()).toBe(0)
+    expect(b.springs.x.get()).toBe(10)
+  })
+
+  it('stop() halts an in-flight animation where it is', async () => {
+    const ref = SpringRef()
+    const a = new Controller({ x: 0 })
+    ref.add(a)
+
+    ref.start({ x: 100 })
+    await global.advance(3)
+    ref.stop()
+
+    const stopped = a.springs.x.get()
+    expect(stopped).toBeGreaterThan(0)
+    expect(stopped).toBeLessThan(100)
+    expect(a.springs.x.idle).toBe(true)
+
+    // It must not creep towards the goal after being stopped.
+    await global.advance(20)
+    expect(a.springs.x.get()).toBe(stopped)
+  })
+
+  it('pause() freezes an animation and resume() continues it', async () => {
+    const ref = SpringRef()
+    const a = new Controller({ x: 0 })
+    ref.add(a)
+
+    ref.start({ x: 100 })
+    await global.advance(3)
+    ref.pause()
+
+    const paused = a.springs.x.get()
+    await global.advance(20)
+    expect(a.springs.x.get()).toBe(paused) // frozen while paused
+
+    ref.resume()
+    await global.advanceUntilIdle()
+    expect(a.springs.x.get()).toBe(100) // resumes to completion
+  })
+
+  it('update() only queues props; they run on the next start()', async () => {
+    const ref = SpringRef()
+    const a = new Controller({ x: 0 })
+    ref.add(a)
+
+    ref.update({ x: 100 })
+    await global.advance(10)
+    expect(a.springs.x.get()).toBe(0) // queued, not started
+
+    ref.start()
+    await global.advanceUntilIdle()
+    expect(a.springs.x.get()).toBe(100)
+  })
+
+  it('pause(key) only pauses the matching spring', async () => {
+    const ref = SpringRef()
+    const a = new Controller({ x: 0, y: 0 })
+    ref.add(a)
+
+    ref.start({ x: 100, y: 100 })
+    await global.advance(3)
+    ref.pause('x')
+
+    const pausedX = a.springs.x.get()
+    await global.advanceUntilIdle()
+
+    expect(a.springs.x.get()).toBe(pausedX) // x stayed paused
+    expect(a.springs.y.get()).toBe(100) // y ran to completion
+  })
+})

--- a/packages/core/src/components/Spring.test.tsx
+++ b/packages/core/src/components/Spring.test.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react'
+import { render } from 'vitest-browser-react'
+
+import { SpringValue } from '../SpringValue'
+import { Spring } from './Spring'
+
+describe('Spring', () => {
+  it('calls its children with the spring values and mounts the result', async () => {
+    let values: any
+    const { getByTestId } = await render(
+      <Spring from={{ x: 0 }} to={{ x: 100 }}>
+        {styles => {
+          values = styles
+          return <div data-testid="box" />
+        }}
+      </Spring>
+    )
+
+    // The element returned by the render fn is mounted...
+    expect(getByTestId('box').query()).toBeTruthy()
+    // ...and it receives live SpringValues keyed by the animated props.
+    expect(values.x).toBeInstanceOf(SpringValue)
+    expect(values.x.get()).toBe(0)
+
+    await global.advanceUntilIdle()
+    expect(values.x.get()).toBe(100)
+  })
+
+  it('forwards config to the underlying animation', async () => {
+    let values: any
+    await render(
+      <Spring to={{ x: 1 }} config={{ tension: 123 }}>
+        {styles => {
+          values = styles
+          return null
+        }}
+      </Spring>
+    )
+
+    expect(values.x.animation.config.tension).toBe(123)
+  })
+
+  it('applies the `immediate` prop so the value jumps to its goal', async () => {
+    let values: any
+    await render(
+      <Spring from={{ x: 0 }} to={{ x: 100 }} immediate>
+        {styles => {
+          values = styles
+          return null
+        }}
+      </Spring>
+    )
+
+    global.mockRaf.step()
+    expect(values.x.get()).toBe(100)
+  })
+})

--- a/packages/core/src/components/Trail.test.tsx
+++ b/packages/core/src/components/Trail.test.tsx
@@ -1,0 +1,48 @@
+import * as React from 'react'
+import { render } from 'vitest-browser-react'
+
+import { SpringValue } from '../SpringValue'
+import { Trail } from './Trail'
+
+describe('Trail', () => {
+  it('renders one child per item, each with its own spring values', async () => {
+    const seen: Record<number, any> = {}
+    const { getByTestId } = await render(
+      <Trail items={['a', 'b', 'c']} from={{ opacity: 0 }} to={{ opacity: 1 }}>
+        {(item: unknown, index: number) => (values: any) => {
+          seen[index] = values
+          const id = String(item)
+          return <div data-testid={`item-${id}`}>{id}</div>
+        }}
+      </Trail>
+    )
+
+    // One mounted element per item.
+    expect(getByTestId('item-a').query()).toBeTruthy()
+    expect(getByTestId('item-b').query()).toBeTruthy()
+    expect(getByTestId('item-c').query()).toBeTruthy()
+
+    // Each item gets a distinct SpringValue, not a shared reference.
+    expect(seen[0].opacity).toBeInstanceOf(SpringValue)
+    expect(seen[0].opacity).not.toBe(seen[1].opacity)
+    expect(seen[1].opacity).not.toBe(seen[2].opacity)
+
+    await global.advanceUntilIdle()
+    expect(seen[2].opacity.get()).toBe(1)
+  })
+
+  it('skips items whose child returns a falsy value', async () => {
+    const { getByTestId } = await render(
+      <Trail items={['a', 'b']} to={{ opacity: 1 }}>
+        {(item: unknown) =>
+          item === 'b'
+            ? false
+            : () => <div data-testid={`item-${String(item)}`} />
+        }
+      </Trail>
+    )
+
+    expect(getByTestId('item-a').query()).toBeTruthy()
+    expect(getByTestId('item-b').query()).toBeNull()
+  })
+})

--- a/packages/core/src/components/Trail.test.tsx
+++ b/packages/core/src/components/Trail.test.tsx
@@ -2,7 +2,14 @@ import * as React from 'react'
 import { render } from 'vitest-browser-react'
 
 import { SpringValue } from '../SpringValue'
-import { Trail } from './Trail'
+import { Trail as TrailComponent } from './Trail'
+
+// `Trail` renders an array of nodes, which TypeScript <= 5.4 rejects as a JSX
+// element type (TS2786). Cast to a plain component type for the test — we're
+// exercising runtime behaviour, not Trail's JSX typing.
+const Trail = TrailComponent as unknown as (
+  props: any
+) => React.ReactElement | null
 
 describe('Trail', () => {
   it('renders one child per item, each with its own spring values', async () => {

--- a/packages/core/src/components/Transition.test.tsx
+++ b/packages/core/src/components/Transition.test.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react'
+import { render } from 'vitest-browser-react'
+
+import { SpringValue } from '../SpringValue'
+import { Transition } from './Transition'
+
+describe('Transition', () => {
+  it('passes animated styles and the item to the render fn, animating on enter', async () => {
+    let style: any
+    await render(
+      <Transition
+        items={true}
+        from={{ t: 0 }}
+        enter={{ t: 1 }}
+        leave={{ t: 0 }}
+      >
+        {(values, item) => {
+          if (item) style = values
+          return null
+        }}
+      </Transition>
+    )
+
+    expect(style.t).toBeInstanceOf(SpringValue)
+    expect(style.t.get()).toBe(0)
+
+    await global.advanceUntilIdle()
+    expect(style.t.get()).toBe(1)
+  })
+
+  it('keeps a leaving item mounted until its leave animation finishes', async () => {
+    const Comp = ({ show }: { show: boolean }) => (
+      <Transition
+        items={show ? ['x'] : []}
+        keys={(item: string) => item}
+        from={{ t: 0 }}
+        enter={{ t: 1 }}
+        leave={{ t: 0 }}
+      >
+        {(_values, item) => <div data-testid={`item-${item}`}>{item}</div>}
+      </Transition>
+    )
+
+    const screen = await render(<Comp show={true} />)
+    await global.advanceUntilIdle()
+    expect(screen.getByTestId('item-x').query()).toBeTruthy()
+
+    // Removing the item starts its leave animation but keeps it mounted.
+    await screen.rerender(<Comp show={false} />)
+    expect(screen.getByTestId('item-x').query()).toBeTruthy()
+
+    // Once the leave animation settles, the item unmounts.
+    await global.advanceUntilIdle()
+    expect(screen.getByTestId('item-x').query()).toBeNull()
+  })
+})

--- a/packages/core/src/hooks/lifecycleEvents.test.tsx
+++ b/packages/core/src/hooks/lifecycleEvents.test.tsx
@@ -1,0 +1,65 @@
+import * as React from 'react'
+import { render } from 'vitest-browser-react'
+
+import { useSprings } from './useSprings'
+import { useTrail } from './useTrail'
+import { useTransition } from './useTransition'
+
+type Handlers = {
+  onStart: ReturnType<typeof vi.fn>
+  onChange: ReturnType<typeof vi.fn>
+  onRest: ReturnType<typeof vi.fn>
+}
+
+// onStart/onChange/onRest are exhaustively tested on SpringValue and Controller.
+// The risk these tests guard is the *passthrough* path: the multi-spring hooks
+// diff and forward props, and that is where lifecycle callbacks have historically
+// been dropped (see #2532, #2410).
+const cases: { name: string; Comp: React.FC<{ handlers: Handlers }> }[] = [
+  {
+    name: 'useSprings',
+    Comp: ({ handlers }) => {
+      useSprings(2, [
+        { from: { x: 0 }, to: { x: 1 }, ...handlers },
+        { from: { x: 0 }, to: { x: 1 }, ...handlers },
+      ])
+      return null
+    },
+  },
+  {
+    name: 'useTrail',
+    Comp: ({ handlers }) => {
+      useTrail(2, { from: { x: 0 }, to: { x: 1 }, ...handlers })
+      return null
+    },
+  },
+  {
+    name: 'useTransition',
+    Comp: ({ handlers }) => {
+      const transition = useTransition(true, {
+        from: { x: 0 },
+        enter: { x: 1 },
+        ...handlers,
+      })
+      transition(() => null)
+      return null
+    },
+  },
+]
+
+describe.each(cases)('$name lifecycle events', ({ Comp }) => {
+  it('forwards onStart, onChange and onRest to the animation', async () => {
+    const handlers: Handlers = {
+      onStart: vi.fn(),
+      onChange: vi.fn(),
+      onRest: vi.fn(),
+    }
+
+    await render(<Comp handlers={handlers} />)
+    await global.advanceUntilIdle()
+
+    expect(handlers.onStart).toHaveBeenCalled()
+    expect(handlers.onChange).toHaveBeenCalled()
+    expect(handlers.onRest).toHaveBeenCalled()
+  })
+})

--- a/packages/core/src/hooks/lifecycleEvents.test.tsx
+++ b/packages/core/src/hooks/lifecycleEvents.test.tsx
@@ -19,10 +19,11 @@ const cases: { name: string; Comp: React.FC<{ handlers: Handlers }> }[] = [
   {
     name: 'useSprings',
     Comp: ({ handlers }) => {
-      useSprings(2, [
-        { from: { x: 0 }, to: { x: 1 }, ...handlers },
-        { from: { x: 0 }, to: { x: 1 }, ...handlers },
-      ])
+      // `vi.fn()`'s Mock type isn't assignable to the event-handler params in
+      // the array overload on TS <= 5.4, so cast — the object-form hooks below
+      // accept it fine.
+      const props = { from: { x: 0 }, to: { x: 1 }, ...handlers }
+      useSprings(2, [props, props] as any)
       return null
     },
   },

--- a/packages/core/src/hooks/useChain.test.tsx
+++ b/packages/core/src/hooks/useChain.test.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react'
+import { render } from 'vitest-browser-react'
+
+import { SpringRef } from '../SpringRef'
+import { useSpring } from './useSpring'
+import { useChain } from './useChain'
+
+describe('useChain', () => {
+  it('runs each ref in sequence when no timeSteps are given', async () => {
+    const ref1 = SpringRef()
+    const ref2 = SpringRef()
+    let s1: any
+    let s2: any
+
+    const Comp = () => {
+      s1 = useSpring({ ref: ref1, from: { x: 0 }, to: { x: 100 } })
+      s2 = useSpring({ ref: ref2, from: { y: 0 }, to: { y: 100 } })
+      useChain([ref1, ref2])
+      return null
+    }
+
+    await render(<Comp />)
+
+    // The first ref animates immediately...
+    await global.advance(3)
+    expect(s1.x.get()).toBeGreaterThan(0)
+    // ...while the second is gated behind it and hasn't moved.
+    expect(s2.y.get()).toBe(0)
+
+    // Driving to the end shows the second ref does eventually run.
+    await global.advanceUntilValue(s2.y, 100)
+    expect(s2.y.get()).toBeCloseTo(100, 0)
+  })
+
+  it('delays each ref by timeFrame * timeSteps[i]', async () => {
+    const ref1 = SpringRef()
+    const ref2 = SpringRef()
+    let s2: any
+
+    const Comp = () => {
+      useSpring({ ref: ref1, from: { x: 0 }, to: { x: 100 } })
+      s2 = useSpring({ ref: ref2, from: { y: 0 }, to: { y: 100 } })
+      // ref2 is delayed by 1000 * 0.5 = 500ms.
+      useChain([ref1, ref2], [0, 0.5], 1000)
+      return null
+    }
+
+    await render(<Comp />)
+
+    // Before the delay elapses, the second ref stays at its start value.
+    await global.advance(3)
+    expect(s2.y.get()).toBe(0)
+
+    // Once the 500ms delay fires, it begins animating.
+    await global.advanceByTime(500)
+    await global.advance(10)
+    expect(s2.y.get()).toBeGreaterThan(0)
+  })
+})

--- a/packages/core/src/hooks/useInView.test.tsx
+++ b/packages/core/src/hooks/useInView.test.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react'
+import { render } from 'vitest-browser-react'
+
+import { SpringValue } from '../SpringValue'
+import { useInView } from './useInView'
+
+// `useInView` reacts to `IntersectionObserver`, whose callbacks fire on the
+// browser's own schedule and so aren't deterministically drivable here. These
+// tests cover the deterministic public contract: the returned shape for both
+// call signatures and the SSR/old-browser guard when IntersectionObserver is
+// unavailable.
+describe('useInView', () => {
+  it('returns a ref and a boolean that starts false', async () => {
+    let result: any
+    const Comp = () => {
+      result = useInView()
+      const [ref] = result
+      return <div ref={ref} />
+    }
+    await render(<Comp />)
+
+    expect(typeof result[0]).toBe('object') // a React ref object
+    expect(result[1]).toBe(false)
+  })
+
+  it('returns spring values when called with a props function', async () => {
+    let result: any
+    const Comp = () => {
+      result = useInView(() => ({ from: { opacity: 0 }, to: { opacity: 1 } }))
+      const [ref] = result
+      return <div ref={ref} />
+    }
+    await render(<Comp />)
+
+    expect(result[1].opacity).toBeInstanceOf(SpringValue)
+    expect(result[1].opacity.get()).toBe(0)
+  })
+
+  it('does not throw and stays out of view when IntersectionObserver is unavailable', async () => {
+    const original = globalThis.IntersectionObserver
+    // Simulate an SSR / old-browser environment.
+    // @ts-expect-error - deliberately removing the global
+    delete globalThis.IntersectionObserver
+
+    try {
+      let result: any
+      const Comp = () => {
+        result = useInView()
+        const [ref] = result
+        return <div ref={ref} />
+      }
+      await render(<Comp />)
+      expect(result[1]).toBe(false)
+    } finally {
+      globalThis.IntersectionObserver = original
+    }
+  })
+})

--- a/packages/core/src/hooks/useResize.test.tsx
+++ b/packages/core/src/hooks/useResize.test.tsx
@@ -1,0 +1,39 @@
+import * as React from 'react'
+import { render } from 'vitest-browser-react'
+
+import { SpringValue } from '../SpringValue'
+import { useResize } from './useResize'
+
+// `useResize` reports size via `ResizeObserver`, whose callbacks fire on the
+// browser's own schedule (real timers) and so cannot be driven deterministically
+// alongside mock-raf spring stepping. These tests therefore lock the public
+// contract that is deterministic: the returned shape and clean teardown.
+describe('useResize', () => {
+  it('returns width and height spring values initialised to 0', async () => {
+    let values: any
+    const Comp = () => {
+      values = useResize({})
+      return null
+    }
+    await render(<Comp />)
+
+    expect(values.width).toBeInstanceOf(SpringValue)
+    expect(values.height).toBeInstanceOf(SpringValue)
+    expect(values.width.get()).toBe(0)
+    expect(values.height.get()).toBe(0)
+  })
+
+  it('stops its springs on unmount', async () => {
+    let values: any
+    const Comp = () => {
+      values = useResize({})
+      return null
+    }
+    const screen = await render(<Comp />)
+
+    // Unmount runs the cleanup, which stops every spring it owns.
+    screen.unmount()
+    expect(values.width.idle).toBe(true)
+    expect(values.height.idle).toBe(true)
+  })
+})

--- a/packages/core/src/hooks/useScroll.test.tsx
+++ b/packages/core/src/hooks/useScroll.test.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react'
+import { render } from 'vitest-browser-react'
+import { __raf } from '@react-spring/rafz'
+
+import { SpringValue } from '../SpringValue'
+import { useScroll } from './useScroll'
+
+// `useScroll` polls the container's scroll position on every rAF tick (see
+// `onScroll` in @react-spring/shared), so it is fully drivable with mock-raf —
+// no real scroll-event timing required.
+describe('useScroll', () => {
+  const renderScroll = async () => {
+    let values: any
+    const Comp = () => {
+      const ref = React.useRef<HTMLDivElement>(null)
+      values = useScroll({ container: ref as any })
+      return (
+        <div
+          ref={ref}
+          style={{ height: 100, overflow: 'auto' }}
+          data-testid="container"
+        >
+          <div style={{ height: 1000 }} />
+        </div>
+      )
+    }
+    const screen = await render(<Comp />)
+    return { screen, get: () => values }
+  }
+
+  it('returns scroll spring values initialised to 0', async () => {
+    const { get } = await renderScroll()
+    const values = get()
+    for (const key of [
+      'scrollX',
+      'scrollY',
+      'scrollXProgress',
+      'scrollYProgress',
+    ]) {
+      expect(values[key]).toBeInstanceOf(SpringValue)
+      expect(values[key].get()).toBe(0)
+    }
+  })
+
+  it('tracks the container scroll position and progress', async () => {
+    const { screen, get } = await renderScroll()
+    const container = screen.getByTestId('container').element() as HTMLElement
+
+    // scrollLength = scrollHeight (1000) - clientHeight (100) = 900
+    container.scrollTop = 450
+    await global.advance(200)
+
+    expect(get().scrollY.get()).toBeCloseTo(450, 0)
+    expect(get().scrollYProgress.get()).toBeCloseTo(0.5, 1)
+  })
+
+  it('cancels its per-frame scroll loop on unmount', async () => {
+    const { screen } = await renderScroll()
+    await global.advance(2)
+
+    // The poll keeps a pending rAF task alive every frame while mounted.
+    expect(__raf.count()).toBeGreaterThan(0)
+
+    screen.unmount()
+
+    // If cleanup failed, the poll re-queues itself every frame and this never
+    // settles (advanceUntilIdle throws at its frame cap). Draining to idle is
+    // the proof the loop was cancelled.
+    await global.advanceUntilIdle()
+    expect(__raf.count()).toBe(0)
+  })
+})

--- a/packages/parallax/src/parallax.test.tsx
+++ b/packages/parallax/src/parallax.test.tsx
@@ -1,0 +1,71 @@
+import * as React from 'react'
+import { render } from 'vitest-browser-react'
+
+import { Parallax, ParallaxLayer, IParallax } from './index'
+
+// Parallax derives everything from the container's clientHeight, so each test
+// renders inside a positioned, fixed-size wrapper to pin `space` deterministically.
+const Wrapper = ({ children }: { children: React.ReactNode }) => (
+  <div style={{ position: 'relative', width: 400, height: 500 }}>
+    {children}
+  </div>
+)
+
+describe('Parallax', () => {
+  it('exposes the documented IParallax imperative handle', async () => {
+    const ref = React.createRef<IParallax>()
+    await render(
+      <Wrapper>
+        <Parallax pages={3} ref={ref}>
+          <ParallaxLayer offset={0} />
+        </Parallax>
+      </Wrapper>
+    )
+
+    const api = ref.current!
+    expect(typeof api.scrollTo).toBe('function')
+    expect(typeof api.update).toBe('function')
+    expect(typeof api.stop).toBe('function')
+    expect(api.layers).toBeInstanceOf(Set)
+    expect(api.controller).toBeTruthy()
+    expect(api.container.current).toBeTruthy()
+    expect(api.content.current).toBeTruthy()
+    expect(api.horizontal).toBe(false)
+  })
+
+  it('scrollTo() animates the container to the given page offset', async () => {
+    const ref = React.createRef<IParallax>()
+    const { getByTestId } = await render(
+      <Wrapper>
+        <Parallax pages={3} ref={ref} data-testid="container">
+          <ParallaxLayer offset={0} />
+        </Parallax>
+      </Wrapper>
+    )
+    const container = getByTestId('container').element() as HTMLElement
+
+    // space == clientHeight == 500, so page 1 sits at scrollTop 500.
+    expect(ref.current!.space).toBe(500)
+    ref.current!.scrollTo(1)
+    await global.advanceUntilIdle()
+
+    expect(container.scrollTop).toBeCloseTo(500, 0)
+  })
+
+  it('sizes a layer by its `factor`', async () => {
+    const { getByTestId } = await render(
+      <Wrapper>
+        <Parallax pages={3}>
+          <ParallaxLayer offset={0} factor={2} data-testid="layer" />
+        </Parallax>
+      </Wrapper>
+    )
+
+    // A frame applies the immediate setHeight(space * factor) from update().
+    await global.advance(2)
+
+    const layer = getByTestId('layer').element() as HTMLElement
+    // space (500) * factor (2) = 1000px tall.
+    expect(layer.style.height).toBe('1000px')
+  })
+})

--- a/targets/web/src/animated.test.tsx
+++ b/targets/web/src/animated.test.tsx
@@ -2,7 +2,12 @@ import * as React from 'react'
 import { forwardRef } from 'react'
 import { render } from 'vitest-browser-react'
 import createMockRaf, { MockRaf } from '@react-spring/mock-raf'
-import { FluidValue, Globals, callFluidObservers } from '@react-spring/shared'
+import {
+  FluidValue,
+  Globals,
+  callFluidObservers,
+  getFluidObservers,
+} from '@react-spring/shared'
 import { SpringValue, Animatable } from '@react-spring/core'
 
 import { a } from './index'
@@ -241,6 +246,62 @@ describe('animated component', () => {
     expect(wrapper.style.transformStyle).toBe('preserve-3d')
     expect(wrapper.style.transform).toBe('translateX(40px) scale(1, 2)')
   })
+  it('composes a `matrix` transform from an array of values', async () => {
+    const { getByTestId } = await render(
+      <a.div style={{ matrix: [1, 2, 3, 4, 5, 6] }} data-testid="wrapper" />
+    )
+    const wrapper = getByTestId('wrapper').element() as HTMLElement
+    expect(wrapper.style.transform).toBe('matrix(1, 2, 3, 4, 5, 6)')
+  })
+  it('composes a `matrix3d` transform from an array of values', async () => {
+    const { getByTestId } = await render(
+      <a.div
+        style={{
+          matrix3d: [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 10, 20, 30, 1],
+        }}
+        data-testid="wrapper"
+      />
+    )
+    const wrapper = getByTestId('wrapper').element() as HTMLElement
+    expect(wrapper.style.transform).toBe(
+      'matrix3d(1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 10, 20, 30, 1)'
+    )
+  })
+  it('applies `deg` units to each value of a `skew` array', async () => {
+    const { getByTestId } = await render(
+      <a.div style={{ skew: [10, 20] }} data-testid="wrapper" />
+    )
+    const wrapper = getByTestId('wrapper').element() as HTMLElement
+    expect(wrapper.style.transform).toBe('skew(10deg, 20deg)')
+  })
+  it('sets CSS custom properties without appending a `px` unit', async () => {
+    const size = spring(10)
+    const { getByTestId } = await render(
+      <a.div style={{ '--size': size } as any} data-testid="wrapper" />
+    )
+    const el = getByTestId('wrapper').element() as HTMLElement
+    expect(el.style.getPropertyValue('--size')).toBe('10')
+    size.set(20)
+    mockRaf.step()
+    expect(el.style.getPropertyValue('--size')).toBe('20')
+  })
+  it('does not append `px` to unitless SVG style props (strokeDashoffset)', async () => {
+    const dashoffset = spring(10)
+    const { getByTestId } = await render(
+      <a.svg viewBox="0 0 100 100">
+        <a.path
+          d="M0 0 L100 100"
+          style={{ strokeDashoffset: dashoffset }}
+          data-testid="path"
+        />
+      </a.svg>
+    )
+    const path = getByTestId('path').element() as unknown as SVGPathElement
+    expect(path.style.strokeDashoffset).toBe('10')
+    dashoffset.set(25)
+    mockRaf.step()
+    expect(path.style.strokeDashoffset).toBe('25')
+  })
 })
 
 describe('animated component attribute removal', () => {
@@ -310,6 +371,22 @@ describe('animated component attribute removal', () => {
     mockRaf.step()
     expect(el.getAttribute('tabindex')).toBe('0')
     expect(el.hasAttribute('tabindex')).toBe(true)
+  })
+})
+
+describe('animated component lifecycle', () => {
+  it('stops observing an animated value after it unmounts', async () => {
+    const opacity = spring(0)
+    const { unmount } = await render(
+      <a.div style={{ opacity }} data-testid="wrapper" />
+    )
+
+    // While mounted, the animated node observes the spring.
+    expect(getFluidObservers(opacity)?.size ?? 0).toBeGreaterThan(0)
+
+    // Unmounting must detach that observer so the spring can be collected.
+    unmount()
+    expect(getFluidObservers(opacity)?.size ?? 0).toBe(0)
   })
 })
 


### PR DESCRIPTION
Adds regression tests for public APIs that previously had no direct coverage, so upcoming refactors and releases can move with more confidence. The lens throughout is confidence in the public surface consumers depend on — not line coverage.

### What's now guarded

- **Render-prop components** — `Spring`, `Trail`, `Transition`: children receive live spring values, props/`config`/`immediate` are forwarded, falsy children are skipped, and a leaving item stays mounted until its leave animation settles.
- **DOM hooks** — `useScroll` (scroll tracking + per-frame loop cleanup), `useResize` and `useInView` (returned shape, the SSR/no-`IntersectionObserver` guard, clean unmount), and `useChain` (sequential ordering and `timeSteps` delay).
- **Imperative `SpringRef`** — add/delete, `start`/`set` in both object and function forms, `stop`, `pause`/`resume`, `update` queuing, and key-filtered `pause`.
- **Lifecycle events** — `useSprings`/`useTrail`/`useTransition` forward `onStart`/`onChange`/`onRest`.
- **Web target** — `matrix`/`matrix3d`/`skew` transforms, CSS custom properties (no `px` suffix), unitless SVG `strokeDashoffset`, and an unmount observer-leak guard.
- **Parallax** — the `IParallax` ref API, `scrollTo`, and layer `factor` sizing.