### PR TITLE
chore(ci): move turbo caching to actions/cache via shared setup action

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,36 @@
+name: Setup
+description: pnpm + node + install, with optional Turbo cache. Run after checkout.
+inputs:
+  node-version:
+    description: Override node version; empty uses .nvmrc
+    default: ''
+  registry-url:
+    description: npm registry URL (release jobs only)
+    default: ''
+  turbo-cache:
+    description: Restore/save the .turbo cache (build jobs only)
+    default: 'false'
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v6
+
+    - uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node-version }}
+        node-version-file: ${{ inputs.node-version == '' && '.nvmrc' || '' }}
+        registry-url: ${{ inputs.registry-url }}
+        cache: pnpm
+
+    - name: Install
+      run: pnpm install --frozen-lockfile
+      shell: bash
+
+    - name: Cache turbo
+      if: ${{ inputs.turbo-cache == 'true' }}
+      uses: actions/cache@v5
+      with:
+        path: .turbo
+        key: ${{ runner.os }}-turbo-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-turbo-

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -5,10 +5,6 @@ on:
     branches:
       - main
 
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -22,16 +18,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-
-      - uses: actions/setup-node@v6
+      - uses: ./.github/actions/setup
         with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-
-      - name: Install
-        run: pnpm install --frozen-lockfile
+          turbo-cache: 'true'
 
       - name: Build packages
         run: pnpm build --filter=!@react-spring/docs

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -6,10 +6,6 @@ on:
       - 'main'
   pull_request: {}
 
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -27,17 +23,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup node
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-
-      - name: Install
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
 
       - name: Lint
         run: pnpm lint

--- a/.github/workflows/experimental.yml
+++ b/.github/workflows/experimental.yml
@@ -3,10 +3,6 @@ name: 'Experimental Releases'
 on:
   workflow_dispatch:
 
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -30,16 +26,9 @@ jobs:
       - name: Setup npmrc
         run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" >> .npmrc
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-
-      - uses: actions/setup-node@v6
+      - uses: ./.github/actions/setup
         with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-
-      - name: Install
-        run: pnpm install --frozen-lockfile
+          turbo-cache: 'true'
 
       - name: Build
         run: pnpm build-ci

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -4,10 +4,6 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -53,19 +49,10 @@ jobs:
             exit 0
           fi
 
-      - name: Setup pnpm
-        if: steps.version.outputs.NEXT_VERSION
-        uses: pnpm/action-setup@v6
-
-      - uses: actions/setup-node@v6
+      - uses: ./.github/actions/setup
         if: steps.version.outputs.NEXT_VERSION
         with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-
-      - name: Install
-        if: steps.version.outputs.NEXT_VERSION
-        run: pnpm install --frozen-lockfile
+          turbo-cache: 'true'
 
       - name: Build
         if: steps.version.outputs.NEXT_VERSION

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,6 @@ on:
       - 'next'
   workflow_dispatch:
 
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: false
@@ -31,22 +27,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup node
-        uses: actions/setup-node@v6
+      - uses: ./.github/actions/setup
         with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
           registry-url: 'https://registry.npmjs.org'
+          turbo-cache: 'true'
 
       # npm Trusted Publishing requires npm >= 11.5.1; Node 22 LTS still ships npm 10.x
       - name: Upgrade npm
         run: npm install -g npm@latest
-
-      - name: Install
-        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build-ci

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,10 +6,6 @@ on:
       - 'main'
   pull_request: {}
 
-env:
-  TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
-  TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
@@ -35,6 +31,7 @@ jobs:
               - 'vitest.config.ts'
               - '.github/publish-ci/**/package-lock.json'
               - '.github/workflows/*.yml'
+              - '.github/actions/**'
               - 'package.json'
   build:
     needs: changes
@@ -46,17 +43,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup node
-        uses: actions/setup-node@v6
+      - uses: ./.github/actions/setup
         with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-
-      - name: Install
-        run: pnpm install --frozen-lockfile
+          turbo-cache: 'true'
 
       - name: Build
         run: pnpm build-ci --filter=!@react-spring/docs
@@ -96,7 +85,7 @@ jobs:
 
   test-unit:
     name: 'Test:unit'
-    needs: [build]
+    needs: [changes]
     if: ${{ needs.changes.outputs.packages == 'true' }}
     runs-on: ubuntu-latest
     strategy:
@@ -107,20 +96,9 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup node ${{ matrix.node }}
-        uses: actions/setup-node@v6
+      - uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node }}
-          cache: 'pnpm'
-
-      - name: Install
-        run: pnpm install --frozen-lockfile
-
-      - name: Build
-        run: pnpm build-ci
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5
@@ -136,7 +114,7 @@ jobs:
 
   test-types:
     name: 'Test:types with TS ${{ matrix.ts }}'
-    needs: [build]
+    needs: [changes]
     if: ${{ needs.changes.outputs.packages == 'true' }}
     runs-on: ubuntu-latest
     strategy:
@@ -147,17 +125,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup node
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: '.nvmrc'
-          cache: 'pnpm'
-
-      - name: Install
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
 
       - name: Install TypeScript ${{ matrix.ts }}
         run: pnpm add -w typescript@${{ matrix.ts }}
@@ -171,7 +139,7 @@ jobs:
           pnpm test:ts
 
   test-e2e:
-    needs: [build]
+    needs: [changes]
     if: ${{ needs.changes.outputs.packages == 'true' }}
     name: 'Test:E2E'
     runs-on: ubuntu-latest
@@ -180,17 +148,7 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v6
-
-      - name: Setup node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24.16.0'
-          cache: 'pnpm'
-
-      - name: Install
-        run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup
 
       - name: Cache Playwright browsers
         uses: actions/cache@v5

--- a/turbo.json
+++ b/turbo.json
@@ -12,7 +12,7 @@
     "build": {
       "outputs": ["dist/**", "public/build/**", "api/**"],
       "dependsOn": ["^build"],
-      "inputs": ["src/**/*.tsx", "src/**/*.ts", "../../tsup.config.base.ts"]
+      "inputs": ["src/**/*.tsx", "src/**/*.ts", "../../tsdown.config.base.mjs"]
     },
     "pack": {}
   }


### PR DESCRIPTION
### Why

The Turbo remote cache has been silently dead — `TURBO_TOKEN` fails authentication on every run, so CI rebuilds everything cold (`0 cached, 8 total`) and the logs are littered with auth warnings.

### What

Switch to GitHub's native `actions/cache` for Turbo's `.turbo` directory, so build output is reused across runs with no Vercel token required. A shared `setup` composite action absorbs the pnpm + node + install boilerplate every workflow was hand-rolling, with an opt-in flag for the cache.

Alongside this, the Tests workflow stops doing work it never needed: unit tests run against source, so the redundant build step is gone, and the unit/type/e2e jobs no longer serialise behind a build job whose artifacts they never consumed. The Turbo build input was also still pointing at the removed `tsup` config — it now tracks `tsdown`, so bundler-config changes correctly invalidate the cache.
