### PR TITLE
fix: cache output number parsing in createStringInterpolator

### DIFF
--- a/.changeset/clever-islands-dig.md
+++ b/.changeset/clever-islands-dig.md
@@ -1,0 +1,13 @@
+---
+'@react-spring/shared': patch
+'@react-spring/animated': patch
+'@react-spring/core': patch
+'@react-spring/mock-raf': patch
+'@react-spring/parallax': patch
+'@react-spring/rafz': patch
+'@react-spring/types': patch
+'@react-spring/three': patch
+'@react-spring/web': patch
+---
+
+improve performance of string interpolation when used with large ammounts of data

--- a/packages/shared/src/stringInterpolation.ts
+++ b/packages/shared/src/stringInterpolation.ts
@@ -80,9 +80,10 @@ export const createStringInterpolator = (
   // a whole number. Whole-number keyframes are left untouched so that
   // values like the alpha channel in `rgba(…, 0)` → `rgba(…, 1)` keep
   // their natural sub-frame precision.
-  const decimalCounts = getNumbers(output[0]).map((_, pos) => {
-    const counts = output.map(value => {
-      const token = getNumbers(value)[pos]
+  const allTokens = output.map(value => getNumbers(value))
+  const decimalCounts = allTokens[0].map((_, pos) => {
+    const counts = allTokens.map(tokens => {
+      const token = tokens[pos]
       const dot = token.indexOf('.')
       return dot === -1 ? 0 : token.length - dot - 1
     })


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure you're familiar with and follow the instructions in the contributing guidelines (found in the CONTRIBUTING.md file).

Please fill out the information below to expedite the review and (hopefully) merge of your pull request!
-->

### Why

Starting in version 10.1.0, this code is very slow when showing a chart with a large number of points.

### What

Instead of calculating the value in every iteration of the loop, the numbers are only calculated once.

### Checklist

<!-- Have you done all of these things?  -->

<!--
To check an item, place an "x" in the box like so: "- [x] Documentation"
Remove items that are irrelevant to your changes.
-->

- [x] Ready to be merged

<!-- if you untick ready to be merged & you haven't submitted as a draft, we will change it to draft. -->

<!-- feel free to add additional comments -->
