### PR TITLE
fix(core): propagate immediate flag to to-array chain steps

### DIFF
--- a/.changeset/immediate-to-array-chain.md
+++ b/.changeset/immediate-to-array-chain.md
@@ -1,0 +1,5 @@
+---
+"@react-spring/core": patch
+---
+
+Propagate the `immediate` flag to every step of a `to` array chain. Previously, `immediate: true` was ignored when combined with an array `to` prop, so the animation chain would animate each step sequentially instead of jumping instantly to the final value.

--- a/packages/core/src/Controller.test.ts
+++ b/packages/core/src/Controller.test.ts
@@ -719,6 +719,22 @@ describe('Controller', () => {
       expect(onStart).toHaveBeenCalled()
       expect(onRest).toHaveBeenCalled()
     })
+
+    // Regression test for https://github.com/pmndrs/react-spring/issues/2204
+    it('applies `immediate` to every step of a `to` array chain', async () => {
+      const ctrl = new Controller<{ t: number }>({ t: 0 })
+      const { t } = ctrl.springs
+
+      ctrl.start({
+        to: [{ t: 1 }, { t: 2 }],
+        immediate: true,
+      })
+
+      await global.advanceUntilIdle()
+
+      // With `immediate`, the chain must jump straight to the last step's goal.
+      expect(t.get()).toBe(2)
+    })
   })
 
   // Regression test for https://github.com/pmndrs/react-spring/issues/2208

--- a/packages/core/src/runAsync.ts
+++ b/packages/core/src/runAsync.ts
@@ -152,8 +152,14 @@ export function runAsync<T extends AnimationTarget>(
       // Async sequence
       if (is.arr(to)) {
         animating = (async (queue: any[]) => {
-          for (const props of queue) {
-            await animate(props)
+          for (const queueProps of queue) {
+            // When the parent update has `immediate: true`, propagate it to
+            // every step in the array so that each spring starts instantly
+            // instead of animating. (#2204)
+            if (props.immediate === true && queueProps.immediate === undefined) {
+              queueProps.immediate = true
+            }
+            await animate(queueProps)
           }
         })(to)
       }


### PR DESCRIPTION
## Summary

When `immediate: true` is set with an array `to` prop, each step in the chain should start immediately. Previously the flag was only checked in `SpringValue.start()`, but when `to` is an array, `SpringValue.start()` delegates to `runAsync()`, which did not propagate `immediate` to each step.

This caused the chain to animate each step sequentially instead of jumping immediately to the final value.

## Changes

- In `runAsync.ts`: propagate `props.immediate` to each step in the `to` array chain when it is not explicitly set on the step itself

## Test plan

- Added regression test in `Controller.test.ts`
- Changeset added: `@react-spring/core: patch`

## Links

- Fixes pmndrs/react-spring#2204