### PR TITLE
fix(core): prevent infinite loop when skipAnimation + loop (#2409)

### DIFF
--- a/packages/core/src/SpringValue.test.ts
+++ b/packages/core/src/SpringValue.test.ts
@@ -757,6 +757,21 @@ function describeLoopProp() {
       expect(spring.idle).toBeFalsy()
     })
 
+    it('settles immediately when skipAnimation is enabled (#2409)', async () => {
+      const spring = new SpringValue(0)
+      Globals.assign({ skipAnimation: true })
+      spring.start(1, { loop: true })
+
+      await global.advanceUntilIdle()
+
+      // With skipAnimation, the spring must settle at its goal instead of
+      // re-entering the loop synchronously (which used to hang the tab).
+      expect(spring.get()).toBe(1)
+      expect(spring.idle).toBeTruthy()
+
+      Globals.assign({ skipAnimation: false })
+    })
+
     it('can be combined with the "reverse" prop', async () => {
       const spring = new SpringValue(0)
       spring.start(1, { config: { duration: frameLength * 3 } })

--- a/packages/core/src/SpringValue.ts
+++ b/packages/core/src/SpringValue.ts
@@ -633,7 +633,10 @@ export class SpringValue<T = any> extends FrameValue<T> {
         start: this._merge.bind(this, range),
       },
     }).then(result => {
-      if (props.loop && result.finished && !(isLoop && result.noop)) {
+      // When animations are skipped (G.skipAnimation), the "finish" path runs
+      // synchronously inside _resume(). Re-entering the loop there would recurse
+      // infinitely without yielding to the event loop and hang the tab. (#2409)
+      if (props.loop && !G.skipAnimation && result.finished && !(isLoop && result.noop)) {
         const nextProps = createLoopUpdate(props)
         if (nextProps) {
           return this._update(nextProps, true)


### PR DESCRIPTION
## Summary

When `skipAnimation: true` (via `Globals.assign({ skipAnimation: true })`) is combined with `loop: true`, the tab hangs at 100% CPU. This reproduces with:

```js
import { Globals, SpringValue } from "@react-spring/web";
Globals.assign({ skipAnimation: true });
new SpringValue(0, { to: 1, loop: true });
```

## Root cause

With `skipAnimation` enabled, `SpringValue._resume()` calls `this.finish()` synchronously instead of deferring to the frameloop. The promise resolves immediately, and the `.then()` loop callback re-enters via `_update() -> _start() -> _resume() -> finish()`. Since nothing yields to the event loop, this recurses infinitely and freezes the tab.

## Changes

- In `SpringValue.ts`, skip the loop re-trigger in the `.then()` callback when `G.skipAnimation` is enabled.
- The spring settles at its goal value instead of looping.

## Test plan

- New regression test in `SpringValue.test.ts` (loop + skipAnimation settles immediately at goal, becomes idle).

## Links

- Fixes pmndrs/react-spring#2409