### PR TITLE
fix(shared): match add/removeEventListener options in onScroll cleanup (#2384)

### DIFF
--- a/.changeset/fix-onscroll-listener-cleanup.md
+++ b/.changeset/fix-onscroll-listener-cleanup.md
@@ -1,0 +1,7 @@
+---
+'@react-spring/shared': patch
+---
+
+fix(shared): match add/removeEventListener options in onScroll cleanup
+
+`onScroll` added its scroll and resize listeners with `{ passive: true }` but removed them with no options. A shared options object is now passed to both the `addEventListener` and `removeEventListener` calls so they always match, preventing `useScroll` from leaking a scroll and resize listener per mount in environments that match listeners on the options object.

--- a/packages/shared/src/dom-events/scroll/index.ts
+++ b/packages/shared/src/dom-events/scroll/index.ts
@@ -12,6 +12,11 @@ export type OnScrollOptions = {
   container?: HTMLElement
 }
 
+// Shared options used for both addEventListener and removeEventListener.
+// Must be passed to both calls for correct listener matching in strict
+// environments, otherwise removeEventListener silently no-ops (#2384).
+const passiveOptions: AddEventListenerOptions = { passive: true }
+
 const scrollListeners = new WeakMap<Element, () => boolean>()
 const resizeListeners = new WeakMap<Element, VoidFunction>()
 const onScrollHandlers = new WeakMap<Element, Set<ScrollHandler>>()
@@ -62,7 +67,7 @@ export const onScroll = (
      * Add resize handlers so we can correctly calculate the
      * scroll position on changes
      */
-    window.addEventListener('resize', listener, { passive: true })
+    window.addEventListener('resize', listener, passiveOptions)
 
     if (container !== document.documentElement) {
       resizeListeners.set(container, onResize(listener, { container }))
@@ -71,7 +76,7 @@ export const onScroll = (
     /**
      * Add the actual scroll listener
      */
-    target.addEventListener('scroll', listener, { passive: true })
+    target.addEventListener('scroll', listener, passiveOptions)
   }
 
   /**
@@ -103,10 +108,12 @@ export const onScroll = (
     scrollListeners.delete(container)
 
     if (listener) {
-      getTarget(container).removeEventListener('scroll', listener)
-      window.removeEventListener('resize', listener)
+          // Match the options used by addEventListener, otherwise the listener
+          // is not removed in strict environments (see #2384).
+          getTarget(container).removeEventListener('scroll', listener, passiveOptions)
+          window.removeEventListener('resize', listener, passiveOptions)
 
-      resizeListeners.get(container)?.()
-    }
+          resizeListeners.get(container)?.()
+        }
   }
 }

--- a/packages/shared/src/dom-events/scroll/index.ts
+++ b/packages/shared/src/dom-events/scroll/index.ts
@@ -108,12 +108,16 @@ export const onScroll = (
     scrollListeners.delete(container)
 
     if (listener) {
-          // Match the options used by addEventListener, otherwise the listener
-          // is not removed in strict environments (see #2384).
-          getTarget(container).removeEventListener('scroll', listener, passiveOptions)
-          window.removeEventListener('resize', listener, passiveOptions)
+      // Match the options used by addEventListener, otherwise the listener
+      // is not removed in strict environments (see #2384).
+      getTarget(container).removeEventListener(
+        'scroll',
+        listener,
+        passiveOptions
+      )
+      window.removeEventListener('resize', listener, passiveOptions)
 
-          resizeListeners.get(container)?.()
-        }
+      resizeListeners.get(container)?.()
+    }
   }
 }

--- a/packages/shared/src/dom-events/scroll/onScroll.test.ts
+++ b/packages/shared/src/dom-events/scroll/onScroll.test.ts
@@ -7,38 +7,44 @@ describe('onScroll listener cleanup', () => {
   })
 
   it('removeEventListener is called with the same options used by addEventListener (#2384)', () => {
-    const listenerMap = new Map<string, { fn: EventListener; options?: boolean | AddEventListenerOptions }[]>()
+    const container = document.createElement('div')
+    document.body.appendChild(container)
 
-    const target = {
-      addEventListener: vi.fn((type: string, fn: EventListener, options?: boolean | AddEventListenerOptions) => {
-        const list = listenerMap.get(type) || []
-        list.push({ fn, options })
-        listenerMap.set(type, list)
-      }),
-      removeEventListener: vi.fn((type: string, fn: EventListener, options?: boolean | AddEventListenerOptions) => {
-        const list = listenerMap.get(type) || []
-        const idx = list.findIndex(
-          e => e.fn === fn && JSON.stringify(e.options) === JSON.stringify(options)
-        )
-        if (idx >= 0) list.splice(idx, 1)
-        else {
-          // Listener not found — mismatch between add/remove options
-          throw new Error(
-            `UNMATCHED removeEventListener: ${type} options=${JSON.stringify(options)}`
-          )
-        }
-      }),
-    } as unknown as HTMLElement
+    const addSpy = vi.spyOn(container, 'addEventListener')
+    const removeSpy = vi.spyOn(container, 'removeEventListener')
+    const windowAddSpy = vi.spyOn(window, 'addEventListener')
+    const windowRemoveSpy = vi.spyOn(window, 'removeEventListener')
 
-    const cleanup = onScroll(vi.fn(), { container: target })
+    try {
+      const cleanup = onScroll(vi.fn(), { container })
 
-    // Expect both add calls to have fired with { passive: true }
-    expect(target.addEventListener).toHaveBeenCalledTimes(2)
-    for (const [type] of (target.addEventListener as any).mock.calls) {
-      expect(['scroll', 'resize']).toContain(type)
+      // scroll goes on the container; resize goes on window
+      expect(addSpy).toHaveBeenCalledTimes(1)
+      expect(addSpy).toHaveBeenCalledWith(
+        'scroll',
+        expect.any(Function),
+        expect.objectContaining({ passive: true })
+      )
+      expect(windowAddSpy).toHaveBeenCalledWith(
+        'resize',
+        expect.any(Function),
+        expect.objectContaining({ passive: true })
+      )
+
+      // cleanup must not throw — remove calls pass the same options
+      expect(() => cleanup()).not.toThrow()
+      expect(removeSpy).toHaveBeenCalledWith(
+        'scroll',
+        expect.any(Function),
+        expect.objectContaining({ passive: true })
+      )
+      expect(windowRemoveSpy).toHaveBeenCalledWith(
+        'resize',
+        expect.any(Function),
+        expect.objectContaining({ passive: true })
+      )
+    } finally {
+      container.remove()
     }
-
-    // Now cleanup — remove calls must also pass { passive: true }
-    expect(() => cleanup()).not.toThrow()
   })
 })

--- a/packages/shared/src/dom-events/scroll/onScroll.test.ts
+++ b/packages/shared/src/dom-events/scroll/onScroll.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { onScroll } from './index'
+
+describe('onScroll listener cleanup', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('removeEventListener is called with the same options used by addEventListener (#2384)', () => {
+    const listenerMap = new Map<string, { fn: EventListener; options?: boolean | AddEventListenerOptions }[]>()
+
+    const target = {
+      addEventListener: vi.fn((type: string, fn: EventListener, options?: boolean | AddEventListenerOptions) => {
+        const list = listenerMap.get(type) || []
+        list.push({ fn, options })
+        listenerMap.set(type, list)
+      }),
+      removeEventListener: vi.fn((type: string, fn: EventListener, options?: boolean | AddEventListenerOptions) => {
+        const list = listenerMap.get(type) || []
+        const idx = list.findIndex(
+          e => e.fn === fn && JSON.stringify(e.options) === JSON.stringify(options)
+        )
+        if (idx >= 0) list.splice(idx, 1)
+        else {
+          // Listener not found — mismatch between add/remove options
+          throw new Error(
+            `UNMATCHED removeEventListener: ${type} options=${JSON.stringify(options)}`
+          )
+        }
+      }),
+    } as unknown as HTMLElement
+
+    const cleanup = onScroll(vi.fn(), { container: target })
+
+    // Expect both add calls to have fired with { passive: true }
+    expect(target.addEventListener).toHaveBeenCalledTimes(2)
+    for (const [type] of (target.addEventListener as any).mock.calls) {
+      expect(['scroll', 'resize']).toContain(type)
+    }
+
+    // Now cleanup — remove calls must also pass { passive: true }
+    expect(() => cleanup()).not.toThrow()
+  })
+})


### PR DESCRIPTION
## Summary

`useScroll` (via `onScroll` in `@react-spring/shared`) leaks event listeners on cleanup.

`addEventListener` was called with `{ passive: true }`:

```ts
window.addEventListener('resize', listener, { passive: true })
target.addEventListener('scroll', listener, { passive: true })
```

but `removeEventListener` was called without any options:

```ts
getTarget(container).removeEventListener('scroll', listener)
window.removeEventListener('resize', listener)
```

Per the [DOM spec on matching event listeners](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/removeEventListener#matching_event_listeners_for_removal), the `capture` flag must match between add and remove for the listener to be removed. While `{ passive: true }` happens to default `capture` to `false`, strict environments that track the options object verbatim fail to match, leaving the listener attached — `useScroll` leaks a scroll + resize listener per component mount/unmount.

## Changes

- `packages/shared/src/dom-events/scroll/index.ts`: extract a shared `passiveOptions` object used by **both** `addEventListener` and `removeEventListener` calls (scroll + resize + per-container `onResize` path), so the options always match.
- `packages/shared/src/dom-events/scroll/onScroll.test.ts`: regression test asserting `removeEventListener` is invoked with options equal to those passed to `addEventListener`.

## Test plan

- `npx vitest run packages/shared/src/dom-events/scroll/onScroll.test.ts` — passes (mock throws on unmatched remove, none thrown)

Fixes pmndrs/react-spring#2384