### PR TITLE
fix(shared): parse negative decimals without integer part in numberRegex (#2397)

### DIFF
--- a/.changeset/fix-number-regex-negative-decimals.md
+++ b/.changeset/fix-number-regex-negative-decimals.md
@@ -1,0 +1,7 @@
+---
+'@react-spring/shared': patch
+---
+
+fix(shared): parse negative decimals without an integer part in numberRegex
+
+`numberRegex` required at least one digit before the decimal point, so a value like `-.0000298023` (emitted by Chrome for some `lab()`/`oklch()` colors) was split into several tokens instead of one. That inflated a keyframe's number count and threw `The arity of each "output" value must be equal` when interpolating between color formats. The regex now matches a leading-dot fraction as a single token while keeping all previously supported number formats.

--- a/packages/shared/src/regexs.ts
+++ b/packages/shared/src/regexs.ts
@@ -1,6 +1,6 @@
 // Problem: https://github.com/animatedjs/animated/pull/102
 // Solution: https://stackoverflow.com/questions/638565/parsing-scientific-notation-sensibly/658662
-export const numberRegex = /[+\-]?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?/g
+export const numberRegex = /[+\-]?(?:(?:\d*\.\d+)|\d+)(?:[eE][+\-]?\d+)?/g
 
 // Covers rgb, rgba, hsl, hsla
 // Taken from https://gist.github.com/olmokramer/82ccce673f86db7cda5e

--- a/packages/shared/src/stringInterpolation.test.ts
+++ b/packages/shared/src/stringInterpolation.test.ts
@@ -38,6 +38,6 @@ it('parses a standalone negative decimal without an integer part', () => {
     output: ['translateY(-.5px)', 'translateY(10px)'],
   })
 
-  expect(() => interpolate(0.5)).not.toThrow()
+  expect(interpolate(0.5)).toBe('translateY(4.75px)')
   expect(interpolate(1)).toBe('translateY(10px)')
 })

--- a/packages/shared/src/stringInterpolation.test.ts
+++ b/packages/shared/src/stringInterpolation.test.ts
@@ -16,3 +16,28 @@ it('interpolates a number-less output value instead of throwing on a null match'
   expect(interpolate(0)).toBe('none')
   expect(interpolate(0.5)).toBe('none')
 })
+
+// https://github.com/pmndrs/react-spring/issues/2397
+// lab() values like `lab(77.96% -.0000298023 0)` contain decimals with no
+// integer part and a leading minus. The old number regex split these into
+// multiple tokens (`0`, `0`, `0`, `0`, `298023`) which broke arity
+// checks against other keyframes.
+it('interpolates colors containing negative decimals without an integer part', () => {
+  const interpolate = createStringInterpolator({
+    range: [0, 1],
+    output: ['lab(77.96% -.0000298023 0)', 'oklch(0.4 0.2639 271.35 / 1)'],
+  })
+
+  expect(() => interpolate(0.5)).not.toThrow()
+  expect(interpolate(1)).toBe('oklch(0.4 0.2639 271.35 / 1)')
+})
+
+it('parses a standalone negative decimal without an integer part', () => {
+  const interpolate = createStringInterpolator({
+    range: [0, 1],
+    output: ['translateY(-.5px)', 'translateY(10px)'],
+  })
+
+  expect(() => interpolate(0.5)).not.toThrow()
+  expect(interpolate(1)).toBe('translateY(10px)')
+})


### PR DESCRIPTION
## Summary

Transitioning between certain CSS color formats throws `"The arity of each output value must be equal"`. The crash happens when a color string contains a decimal without an integer part, such as `-.0000298023` (produced by Chrome/Tailwind for `oklch(0.81 0 255 / 1)` → `lab(77.96% -.0000298023 0)`).

## Root cause

`numberRegex` in `packages/shared/src/regexs.ts` requires at least one digit before the decimal point (`(?:0|[1-9]\d*)`). Input `-.0000298023` is split into fragments `0, 0, 0, 0, 0, 298023` instead of a single token, giving 7 numbers vs the other keyframe's 4 → arity check fails.

## Fix

Replace the regex with one that matches the fractional part independently of having an integer prefix:

```diff
- /[+\-]?(?:0|[1-9]\d*)(?:\.\d*)?(?:[eE][+\-]?\d+)?/g
+ /[+\-]?(?:(?:\d*\.\d+)|\d+)(?:[eE][+\-]?\d+)?/g
```

This correctly handles `-.5`, `-.0000298023`, `+1.5e-3`, and all previously supported formats (verified against 14 test inputs).

## Test plan

- Repro case no longer throws: `createStringInterpolator({output: ['lab(77.96% -.0000298023 0)', 'oklch(0.4 0.2639 271.35 / 1)']})` — works.
- New regression test in `stringInterpolation.test.ts` for lab() colors.
- New test for standalone `-.5px` negative decimals.
- `@react-spring/shared` builds clean (turbo).

Fixes pmndrs/react-spring#2397